### PR TITLE
AppleCP: Add new AirPods2 model

### DIFF
--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -49,6 +49,7 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
     case 0x2013:
         return Core::AirPods::Model::AirPods_3;
     case 0x200E:
+    case 0x2014:
         return Core::AirPods::Model::AirPods_Pro;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;


### PR DESCRIPTION
I just got a new device and it seems like its product id is new.
For some reason audio does not work in Windows.
But this fix makes this application work.