### PR TITLE
Installer requires the current user level instead of always admin level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,13 @@ if (APD_GENERATE_INSTALLER)
         string(REPLACE "/" "\\\\" ICON_FILEPATH ${ICON_FILEPATH})
         set(CPACK_NSIS_MUI_ICON ${ICON_FILEPATH})
 
+        # Undocumented option and conflicts with `CPACK_COMPONENTS_ALL`
+        #
+        # 10 years old issue: https://cmake.org/Bug/view.php?id=14522
+        #
+        set(CPACK_NSIS_DEFINES)
+        list(APPEND CPACK_NSIS_DEFINES "RequestExecutionLevel highest")
+
         # Create and remove shortcut
         #
         # Workaround for: https://gitlab.kitware.com/cmake/cmake/-/issues/15982
@@ -450,7 +457,6 @@ if (APD_GENERATE_INSTALLER)
         PATTERN "*.exp" EXCLUDE
         PATTERN "*.lib" EXCLUDE
     )
-    set(CPACK_COMPONENTS_ALL ${PROJECT_NAME})
 
     add_custom_command(
         TARGET ${PROJECT_NAME}


### PR DESCRIPTION
Closes #77.

We use an undocumented option `CPACK_NSIS_DEFINES` to override the value of `RequestExecutionLevel` as `highest`, which causes the generated installer to ask admin privilege for admin users and normal user privilege for standard users.

This undocumented option conflicts with `CPACK_COMPONENTS_ALL` (https://cmake.org/Bug/view.php?id=14522)

---

Blocked by https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8767

CPack/NSIS currently has a bug that sets `C:\Program Files (x86)` as the default installation path for standard users, who does not have write access to this path.