### PR TITLE
Add support for Airpods Pro 2(USB-C)

### DIFF
--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -52,6 +52,8 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
         return Core::AirPods::Model::AirPods_Pro;
     case 0x2014:
         return Core::AirPods::Model::AirPods_Pro_2;
+    case 0x2024:
+        return Core::AirPods::Model::AirPods_Pro_2_USB_C;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
         // case 0x2003:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -69,6 +69,7 @@ enum class Model : uint32_t {
     AirPods_3,
     AirPods_Pro,
     AirPods_Pro_2,
+    AirPods_Pro_2_USB_C,
     AirPods_Max,
     Powerbeats_3,
     Beats_X,
@@ -96,6 +97,8 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro";
     case Core::AirPods::Model::AirPods_Pro_2:
         return "AirPods Pro 2";
+    case Core::AirPods::Model::AirPods_Pro_2_USB_C:
+        return "AirPods Pro 2 (USB-C)";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
     case Core::AirPods::Model::Powerbeats_3:

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -422,6 +422,7 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
             videoSize = QSize{900, 450};
             break;
         case Core::AirPods::Model::AirPods_Pro_2:
+        case Core::AirPods::Model::AirPods_Pro_2_USB_C:
             media = "qrc:/Resource/Video/AirPods_Pro_2.avi";
             videoSize = QSize{900, 450};
             break;


### PR DESCRIPTION
Maybe a **Bug**: model ID switchs between `Airpods 2` & `Airpods Pro 2(USB-C)`
So that sometimes the **animation** also switchs between them. (_Low frequency_)

It looks like the `Airpods Pro 2(USB-C)` emits two types of signals.
I don't know if this is an isolated case or an issue with the new AirPods firmware. 
Related issues: #90 

> But everything seems Okay today
 I don't know  why it broken & why it runs
🥹

//`static_assert(false);` prevents me to build so I changed it to `assert(false);`
