### PR TITLE
Remove static_assert(false)

### DIFF
--- a/Source/Logger.h
+++ b/Source/Logger.h
@@ -59,9 +59,6 @@ inline void Log(const spdlog::source_loc &srcloc, Args &&...args)
         else if constexpr (level == Level::Critical) {
             return spdlog::level::critical;
         }
-        else {
-            static_assert(false);
-        }
     }();
 
     spdlog::default_logger_raw()->log(srcloc, spdlogLevel, std::forward<Args>(args)...);


### PR DESCRIPTION
I could not build for this static assertion issue:
The evaluation of static_assert can be initiated by compiler disregarding it's outside an uninstantiated template. 
see [CWG Issue 2518](https://cplusplus.github.io/CWG/issues/2518.html)

Environment:
Compiler: msvc 19.38.33135,  
Generator: Visual Studio 17 Win64 