### PR TITLE
Add support for AirPods Pro 3 (#167)

### DIFF
--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -54,6 +54,8 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
         return Core::AirPods::Model::AirPods_Pro_2;
     case 0x2024:
         return Core::AirPods::Model::AirPods_Pro_2_USB_C;
+    case 0x2027:
+        return Core::AirPods::Model::AirPods_Pro_3;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
         // case 0x2003:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -70,6 +70,7 @@ enum class Model : uint32_t {
     AirPods_Pro,
     AirPods_Pro_2,
     AirPods_Pro_2_USB_C,
+    AirPods_Pro_3,
     AirPods_Max,
     Powerbeats_3,
     Beats_X,
@@ -99,6 +100,8 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro 2";
     case Core::AirPods::Model::AirPods_Pro_2_USB_C:
         return "AirPods Pro 2 (USB-C)";
+    case Core::AirPods::Model::AirPods_Pro_3:
+        return "AirPods Pro 3";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
     case Core::AirPods::Model::Powerbeats_3:

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -423,6 +423,7 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
             break;
         case Core::AirPods::Model::AirPods_Pro_2:
         case Core::AirPods::Model::AirPods_Pro_2_USB_C:
+        case Core::AirPods::Model::AirPods_Pro_3:
             media = "qrc:/Resource/Video/AirPods_Pro_2.avi";
             videoSize = QSize{900, 450};
             break;


### PR DESCRIPTION
#### Add basic BT identification for AirPods Pro 3 now: 
- Add model ID 0x2027 for AirPods Pro 3
- Update model enum and display name
- Using AirPods Pro 2 video for AirPods Pro 3 models