### PR TITLE
Add support for AirPods 4, AirPods 4 (ANC) and AirPods Pro 3

### DIFF
--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -54,6 +54,12 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
         return Core::AirPods::Model::AirPods_Pro_2;
     case 0x2024:
         return Core::AirPods::Model::AirPods_Pro_2_USB_C;
+    case 0x2019:
+        return Core::AirPods::Model::AirPods_4;
+    case 0x201B:
+        return Core::AirPods::Model::AirPods_4_ANC;
+    case 0x2027:
+        return Core::AirPods::Model::AirPods_Pro_3;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
         // case 0x2003:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -70,6 +70,9 @@ enum class Model : uint32_t {
     AirPods_Pro,
     AirPods_Pro_2,
     AirPods_Pro_2_USB_C,
+    AirPods_4,
+    AirPods_4_ANC,
+    AirPods_Pro_3,
     AirPods_Max,
     Powerbeats_3,
     Beats_X,
@@ -99,6 +102,12 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro 2";
     case Core::AirPods::Model::AirPods_Pro_2_USB_C:
         return "AirPods Pro 2 (USB-C)";
+    case Core::AirPods::Model::AirPods_4:
+        return "AirPods 4";
+    case Core::AirPods::Model::AirPods_4_ANC:
+        return "AirPods 4 (ANC)";
+    case Core::AirPods::Model::AirPods_Pro_3:
+        return "AirPods Pro 3";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
     case Core::AirPods::Model::Powerbeats_3:

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -414,6 +414,8 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
             videoSize = QSize{800, 400};
             break;
         case Core::AirPods::Model::AirPods_3:
+        case Core::AirPods::Model::AirPods_4:
+        case Core::AirPods::Model::AirPods_4_ANC:
             media = "qrc:/Resource/Video/AirPods_3.avi";
             videoSize = QSize{900, 450};
             break;
@@ -423,6 +425,7 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
             break;
         case Core::AirPods::Model::AirPods_Pro_2:
         case Core::AirPods::Model::AirPods_Pro_2_USB_C:
+        case Core::AirPods::Model::AirPods_Pro_3:
             media = "qrc:/Resource/Video/AirPods_Pro_2.avi";
             videoSize = QSize{900, 450};
             break;


### PR DESCRIPTION
## Summary

Add basic support for the following models:

- AirPods 4
- AirPods 4 (ANC)
- AirPods Pro 3

## Changes

- Add new model enum entries and display names
- Map Apple model IDs to the new models
- Reuse existing animation fallbacks for new models:
  - AirPods 4 / AirPods 4 (ANC) -> AirPods 3 animation
  - AirPods Pro 3 -> AirPods Pro 2 animation

## Files Changed

- `Source/Core/Base.h`
- `Source/Core/AppleCP.cpp`
- `Source/Gui/MainWindow.cpp`