### PR TITLE
Fix blocking Bluetooth device lookups on UI flows

### DIFF
--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <QVector>
 #include <QMetaObject>
+#include <QCoreApplication>
 
 #include "Bluetooth.h"
 #include "GlobalMedia.h"
@@ -412,11 +413,14 @@ void Manager::OnAutomaticEarDetectionChanged(bool enable)
 
 void Manager::OnBoundDeviceAddressChanged(uint64_t address)
 {
-    std::unique_lock<std::mutex> lock{_mutex};
+    auto requestId = ++_bindRequestId;
 
-    _boundDevice.reset();
-    _deviceConnected = false;
-    _stateMgr.Disconnect();
+    {
+        std::unique_lock<std::mutex> lock{_mutex};
+        _boundDevice.reset();
+        _deviceConnected = false;
+        _stateMgr.Disconnect();
+    }
 
     // Unbind device
     //
@@ -429,26 +433,37 @@ void Manager::OnBoundDeviceAddressChanged(uint64_t address)
     //
     LOG(Info, "Bind a new device.");
 
-    auto optDevice = Bluetooth::DeviceManager::FindDevice(address);
-    if (!optDevice.has_value()) {
-        LOG(Error, "Find device by address failed.");
-        return;
-    }
+    std::thread{[this, address, requestId]() {
+        auto optDevice = Bluetooth::DeviceManager::FindDevice(address);
+        QMetaObject::invokeMethod(qApp, [this, optDevice = std::move(optDevice), requestId]() mutable {
+            if (_bindRequestId.load() != requestId) {
+                LOG(Info, "Ignore stale bind request.");
+                return;
+            }
 
-    _boundDevice = std::move(optDevice);
+            std::lock_guard<std::mutex> lock{_mutex};
 
-    _deviceName = QString::fromStdString([&] {
-        auto name = _boundDevice->GetName();
-        // See https://github.com/SpriteOvO/AirPodsDesktop/issues/15
-        return name.find("Bluetooth") != std::string::npos ? std::string{} : name;
-    }());
+            if (!optDevice.has_value()) {
+                LOG(Error, "Find device by address failed.");
+                return;
+            }
 
-    _boundDevice->CbConnectionStatusChanged() += [this](auto &&...args) {
-        std::lock_guard<std::mutex> lock{_mutex};
-        OnBoundDeviceConnectionStateChanged(std::forward<decltype(args)>(args)...);
-    };
+            _boundDevice = std::move(optDevice);
 
-    OnBoundDeviceConnectionStateChanged(_boundDevice->GetConnectionState());
+            _deviceName = QString::fromStdString([&] {
+                auto name = _boundDevice->GetName();
+                // See https://github.com/SpriteOvO/AirPodsDesktop/issues/15
+                return name.find("Bluetooth") != std::string::npos ? std::string{} : name;
+            }());
+
+            _boundDevice->CbConnectionStatusChanged() += [this](auto &&...args) {
+                std::lock_guard<std::mutex> lock{_mutex};
+                OnBoundDeviceConnectionStateChanged(std::forward<decltype(args)>(args)...);
+            };
+
+            OnBoundDeviceConnectionStateChanged(_boundDevice->GetConnectionState());
+        });
+    }}.detach();
 }
 
 void Manager::OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state)
@@ -596,6 +611,16 @@ std::vector<Bluetooth::Device> GetDevices()
 
     LOG(Info, "AirPods devices count: {} (filtered)", devices.size());
     return devices;
+}
+
+void GetDevicesAsync(std::function<void(std::vector<Core::Bluetooth::Device>)> callback)
+{
+    std::thread{[callback = std::move(callback)]() mutable {
+        auto devices = GetDevices();
+        QMetaObject::invokeMethod(qApp, [callback = std::move(callback), devices = std::move(devices)]() mutable {
+            callback(std::move(devices));
+        });
+    }}.detach();
 }
 
 } // namespace Core::AirPods

--- a/Source/Core/AirPods.h
+++ b/Source/Core/AirPods.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 
 #include "Bluetooth.h"
@@ -163,6 +164,7 @@ private:
     QString _deviceName;
     bool _deviceConnected{false};
     bool _automaticEarDetection{false};
+    std::atomic<uint64_t> _bindRequestId{0};
 
     void OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state);
     void OnStateChanged(Details::StateManager::UpdateEvent updateEvent);
@@ -174,5 +176,6 @@ private:
 };
 
 std::vector<Core::Bluetooth::Device> GetDevices();
+void GetDevicesAsync(std::function<void(std::vector<Core::Bluetooth::Device>)> callback);
 
 } // namespace Core::AirPods

--- a/Source/Core/Bluetooth_win.cpp
+++ b/Source/Core/Bluetooth_win.cpp
@@ -255,20 +255,12 @@ namespace DeviceManager {
 
 std::vector<Device> GetDevicesByState(DeviceState state)
 {
-    std::vector<Device> result;
-    std::thread{[&]() {
-        result = Details::DeviceManager::GetInstance().GetDevicesByState(state);
-    }}.join();
-    return result;
+    return Details::DeviceManager::GetInstance().GetDevicesByState(state);
 }
 
 std::optional<Device> FindDevice(uint64_t address)
 {
-    std::optional<Device> result;
-    std::thread{[&]() {
-        result = Details::DeviceManager::GetInstance().FindDevice(address);
-    }}.join();
-    return result;
+    return Details::DeviceManager::GetInstance().FindDevice(address);
 }
 } // namespace DeviceManager
 

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include <QScreen>
 #include <QPainter>
 #include <QMessageBox>
+#include <QPointer>
 
 #include <Config.h>
 #include "../Helper.h"
@@ -479,49 +480,54 @@ void MainWindow::BindDevice()
 {
     LOG(Info, "BindDevice");
 
-    const auto devices = Core::AirPods::GetDevices();
-    if (devices.empty()) {
-        QMessageBox::warning(
-            this, Config::ProgramName,
-            QMessageBox::tr("No paired device found.\n"
-                            "You need to pair your AirPods in Windows Bluetooth Settings first."));
-        return;
-    }
-
-    int selectedIndex = 0;
-
-    if (devices.size() > 1) {
-        QStringList deviceNames;
-        for (const auto &device : devices) {
-            auto deviceName = device.GetName();
-
-            LOG(Trace, "Device name: '{}'", deviceName);
-            LOG(Trace, "GetProductId: '{}' GetVendorId: '{}'", device.GetProductId(),
-                device.GetVendorId());
-            deviceNames.append(QString::fromStdString(deviceName));
-        }
-
-        SelectWindow selector{tr("Please select your AirPods device below."), deviceNames, this};
-        if (selector.exec() == -1) {
-            LOG(Warn, "selector.exec() == -1");
+    QPointer<MainWindow> self{this};
+    Core::AirPods::GetDevicesAsync([self](std::vector<Core::Bluetooth::Device> devices) {
+        if (!self) {
             return;
         }
 
-        if (!selector.HasResult()) {
-            LOG(Info, "No result for selector.");
+        if (devices.empty()) {
+            QMessageBox::warning(
+                self, Config::ProgramName,
+                QMessageBox::tr("No paired device found.\n"
+                                "You need to pair your AirPods in Windows Bluetooth Settings first."));
             return;
         }
 
-        selectedIndex = selector.GetSeletedIndex();
-        APD_ASSERT(selectedIndex >= 0 && selectedIndex < devices.size());
-    }
+        int selectedIndex = 0;
 
-    const auto &selectedDevice = devices.at(selectedIndex);
+        if (devices.size() > 1) {
+            QStringList deviceNames;
+            for (const auto &device : devices) {
+                auto deviceName = device.GetName();
 
-    LOG(Info, "Selected device index: '{}', device name: '{}'. Bound to this device.",
-        selectedIndex, selectedDevice.GetName());
+                LOG(Trace, "Device name: '{}'", deviceName);
+                deviceNames.append(QString::fromStdString(deviceName));
+            }
 
-    Core::Settings::ModifiableAccess()->device_address = selectedDevice.GetAddress();
+            SelectWindow selector{
+                self->tr("Please select your AirPods device below."), deviceNames, self};
+            if (selector.exec() == -1) {
+                LOG(Warn, "selector.exec() == -1");
+                return;
+            }
+
+            if (!selector.HasResult()) {
+                LOG(Info, "No result for selector.");
+                return;
+            }
+
+            selectedIndex = selector.GetSeletedIndex();
+            APD_ASSERT(selectedIndex >= 0 && selectedIndex < devices.size());
+        }
+
+        const auto &selectedDevice = devices.at(selectedIndex);
+
+        LOG(Info, "Selected device index: '{}', device name: '{}'. Bound to this device.",
+            selectedIndex, selectedDevice.GetName());
+
+        Core::Settings::ModifiableAccess()->device_address = selectedDevice.GetAddress();
+    });
 }
 
 void MainWindow::ControlAutoHideTimer(bool start)


### PR DESCRIPTION
## Summary
- remove redundant thread + join wrappers in Core::Bluetooth::DeviceManager wrappers
- move paired AirPods enumeration (BindDevice) off the UI thread
- make OnBoundDeviceAddressChanged asynchronous and ignore stale bind requests
- marshal async results back to Qt main thread before touching UI/state

## Why
Bluetooth WinRT lookups can block (.get()), so these paths could freeze the UI during bind/select flows.
