### PR TITLE
Add Portuguese (Brazil) (pt_BR) translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ qt5_add_resources(APD_CODE_FILES "Source/Resource/Resource.qrc")
 #           https://stackoverflow.com/a/60848939
 #
 
-set(APD_TRANSLATION_LOCALES de_DE fr_FR ja_JP ko_KR ru_RU zh_CN zh_TW)
+set(APD_TRANSLATION_LOCALES de_DE fr_FR ja_JP ko_KR pt_BR ru_RU zh_CN zh_TW)
 set(APD_TS_DIR "${CMAKE_SOURCE_DIR}/Source/Resource/Translation/")
 set(APD_QM_DIR "${APD_BINARY_OUT_DIR}/translations/")
 

--- a/Source/Resource/Translation/apd_pt_BR.ts
+++ b/Source/Resource/Translation/apd_pt_BR.ts
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>O formato das configurações mudou um pouco e precisa ser reconfigurado.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Olá, bem-vindo ao %1!
+
+Parece que é a primeira vez que você usa este programa.
+Vamos configurar algumas coisas juntos.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Deseja que este programa inicie com o sistema?
+
+Se você usa AirPods frequentemente com este computador, é recomendado clicar em &quot;Sim&quot;.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>Deseja ativar o recurso &quot;baixa latência de áudio&quot;?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Ótimo! Tudo está pronto!
+
+Aproveite.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Você pode me encontrar na bandeja do sistema</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Clique no ícone para ver informações de bateria; clique com o botão direito para personalizar configurações ou sair.</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Baixar nova versão</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Baixar Manualmente</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>Se o download estiver lento ou falhar, você pode:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Ops, ocorreu um erro durante a atualização automática.
+Por favor, baixe e instale a nova versão manualmente.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Notas de versão:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Uma nova versão está disponível!
+
+Versão atual: %1
+Última versão: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>Vincular ao AirPods</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Selecione seu dispositivo AirPods abaixo.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
+        <translation>Alex Martins|</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Contribuidores da Tradução:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Bibliotecas de Terceiros:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Esquerdo</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Direito</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Estojo</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>carregando</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Nova versão disponível!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Configurações</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>Informações do AirPodsDesktop</translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Atualizar agora</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Ignorar esta versão</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Ver versão</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Lembrar mais tarde</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Nenhum dispositivo emparelhado encontrado.
+Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Windows primeiro.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Corrige problemas de reprodução de áudio curta, mas pode aumentar o consumo de bateria.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>Pausa ou retoma a mídia automaticamente quando você remove ou coloca os AirPods nos ouvidos.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Desconectado</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>Aguardando Vinculação</translation>
+    </message>
+</context>
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Selecionar</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>Configurações do AirPodsDesktop</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Abrir diretório de logs</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Alcance máximo de recepção Bluetooth</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>Desvincular AirPods</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Iniciar com o sistema</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Visual</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Exibir bateria na barra de tarefas</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Desativar</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>Quando a bateria estiver baixa</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Como texto</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Como ícone</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Exibir bateria no ícone da bandeja</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Recursos</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Detecção automática de uso</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Baixa latência de áudio</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Código aberto no &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repositório&lt;/span&gt;&lt;/a&gt;, licenciado sob &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Copyright © 2021-2022 SpriteOvO. Todos os direitos reservados.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Adds Brazilian Portuguese (pt_BR) translation.

  All UI strings have been translated, including:
  - System tray menu
  - Settings window
  - Battery popup
  - Update notifications
  - First-run setup dialogs