### PR TITLE
Fix window border aliasing (#133)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(
     AirPodsDesktop
-    VERSION 0.4.1 # Don't forget to bump the version in `vcpkg.json` as well
+    VERSION 0.4.2 # Don't forget to bump the version in `vcpkg.json` as well
     LANGUAGES C CXX
     DESCRIPTION "AirPods desktop user experience enhancement program"
     HOMEPAGE_URL "https://github.com/SpriteOvO/AirPodsDesktop"

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -487,7 +487,7 @@ void MainWindow::PlayAnimation()
 {
     _wantAnimationPlaying = true;
     _view->show();
-    MaybeStartPlayback();
+    TryStartPlayback();
 }
 
 void MainWindow::StopAnimation()
@@ -707,7 +707,7 @@ void MainWindow::OnPlayerError(QMediaPlayer::Error error)
         _mediaPlayer->stop();
 
         // Re-load the media to recover from InvalidMedia state.
-        // This triggers mediaStatusChanged → Loading → LoadedMedia → MaybeStartPlayback → play()
+        // This triggers mediaStatusChanged → Loading → LoadedMedia → TryStartPlayback → play()
         auto currentMedia = _mediaPlayer->media();
         _mediaPlayer->setMedia(QMediaContent{});
         _mediaPlayer->setMedia(currentMedia);
@@ -716,18 +716,17 @@ void MainWindow::OnPlayerError(QMediaPlayer::Error error)
 
 void MainWindow::OnMediaStatusChanged(QMediaPlayer::MediaStatus status)
 {
-    MaybeStartPlayback();
+    TryStartPlayback();
 }
 
-void MainWindow::MaybeStartPlayback()
+void MainWindow::TryStartPlayback()
 {
     if (!_wantAnimationPlaying || !_isVisible) {
         return;
     }
 
     auto status = _mediaPlayer->mediaStatus();
-    if (status == QMediaPlayer::LoadedMedia ||
-        status == QMediaPlayer::BufferedMedia ||
+    if (status == QMediaPlayer::LoadedMedia || status == QMediaPlayer::BufferedMedia ||
         status == QMediaPlayer::StalledMedia)
     {
         _mediaPlayer->play();

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -492,10 +492,6 @@ void MainWindow::PlayAnimation()
     _isAnimationPlaying = true;
     _view->show();
 
-    // Try to play the animation. If play() fails with ResourceError (which can
-    // happen on the very first play when the rendering surface is not yet ready),
-    // OnPlayerError will stop() and set _pendingAnimation, then
-    // OnMediaStatusChanged will retry play() once the media is loaded again.
     _pendingAnimation = true;
     TryPlayPendingAnimation();
 }
@@ -712,8 +708,6 @@ void MainWindow::OnPlayerStateChanged(QMediaPlayer::State newState)
 
 void MainWindow::OnPlayerError(QMediaPlayer::Error error)
 {
-    LOG(Error, "QMediaPlayer error: {}", static_cast<int>(error));
-
     // On the very first play(), QGraphicsVideoItem's rendering surface may not
     // be ready yet, causing a ResourceError. We need to stop the player first
     // (to clear the error state), then retry play() via _pendingAnimation.
@@ -724,6 +718,14 @@ void MainWindow::OnPlayerError(QMediaPlayer::Error error)
         _mediaPlayer->stop();
         _isAnimationPlaying = true;
         _pendingAnimation = true;
+
+        // After a ResourceError, the media status becomes InvalidMedia and
+        // stop() alone does not recover it. Re-invoke SetAnimation to reload
+        // the media, which will trigger OnMediaStatusChanged with LoadedMedia
+        // and then TryPlayPendingAnimation will retry play().
+        auto model = _cacheModel;
+        _cacheModel = std::nullopt;
+        SetAnimation(model);
     }
 }
 

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -478,10 +478,6 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
         _scene->setSceneRect(0, 0, static_cast<qreal>(widgetWidth), static_cast<qreal>(viewHeight));
 
         _mediaPlayer->setMedia(QUrl{media});
-
-        if (_isVisible) {
-            PlayAnimation();
-        }
     }
 
     _cacheModel = model;
@@ -489,11 +485,9 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
 
 void MainWindow::PlayAnimation()
 {
-    _isAnimationPlaying = true;
+    _wantAnimationPlaying = true;
     _view->show();
-
-    _pendingAnimation = true;
-    TryPlayPendingAnimation();
+    MaybeStartPlayback();
 }
 
 void MainWindow::StopAnimation()
@@ -502,8 +496,7 @@ void MainWindow::StopAnimation()
     // I have no idea about this, so let's hide the widget here as a workaround
     _view->hide();
 
-    _isAnimationPlaying = false;
-    _pendingAnimation = false;
+    _wantAnimationPlaying = false;
     _mediaPlayer->stop();
 }
 
@@ -701,54 +694,44 @@ void MainWindow::OnButtonClicked()
 // for loop play
 void MainWindow::OnPlayerStateChanged(QMediaPlayer::State newState)
 {
-    if (newState == QMediaPlayer::StoppedState && _isAnimationPlaying) {
-        _mediaPlayer->play();
+    if (newState == QMediaPlayer::StoppedState && _wantAnimationPlaying) {
+        if (_mediaPlayer->error() == QMediaPlayer::NoError) {
+            _mediaPlayer->play();
+        }
     }
 }
 
 void MainWindow::OnPlayerError(QMediaPlayer::Error error)
 {
-    // On the very first play(), QGraphicsVideoItem's rendering surface may not
-    // be ready yet, causing a ResourceError. We need to stop the player first
-    // (to clear the error state), then retry play() via _pendingAnimation.
-    // Temporarily clear _isAnimationPlaying to prevent OnPlayerStateChanged
-    // from re-playing during stop(), and restore it after for the retry.
-    if (error == QMediaPlayer::ResourceError && _isAnimationPlaying) {
-        _isAnimationPlaying = false;
+    if (error == QMediaPlayer::ResourceError && _wantAnimationPlaying) {
         _mediaPlayer->stop();
-        _isAnimationPlaying = true;
-        _pendingAnimation = true;
 
-        // After a ResourceError, the media status becomes InvalidMedia and
-        // stop() alone does not recover it. Re-invoke SetAnimation to reload
-        // the media, which will trigger OnMediaStatusChanged with LoadedMedia
-        // and then TryPlayPendingAnimation will retry play().
-        auto model = _cacheModel;
-        _cacheModel = std::nullopt;
-        SetAnimation(model);
+        // Re-load the media to recover from InvalidMedia state.
+        // This triggers mediaStatusChanged → Loading → LoadedMedia → MaybeStartPlayback → play()
+        auto currentMedia = _mediaPlayer->media();
+        _mediaPlayer->setMedia(QMediaContent{});
+        _mediaPlayer->setMedia(currentMedia);
     }
 }
 
 void MainWindow::OnMediaStatusChanged(QMediaPlayer::MediaStatus status)
 {
-    TryPlayPendingAnimation();
+    MaybeStartPlayback();
 }
 
-void MainWindow::TryPlayPendingAnimation()
+void MainWindow::MaybeStartPlayback()
 {
-    if (!_pendingAnimation || !_isAnimationPlaying) {
+    if (!_wantAnimationPlaying || !_isVisible) {
         return;
     }
 
-    if (_mediaPlayer->mediaStatus() != QMediaPlayer::LoadedMedia &&
-        _mediaPlayer->mediaStatus() != QMediaPlayer::BufferedMedia &&
-        _mediaPlayer->mediaStatus() != QMediaPlayer::StalledMedia)
+    auto status = _mediaPlayer->mediaStatus();
+    if (status == QMediaPlayer::LoadedMedia ||
+        status == QMediaPlayer::BufferedMedia ||
+        status == QMediaPlayer::StalledMedia)
     {
-        return;
+        _mediaPlayer->play();
     }
-
-    _pendingAnimation = false;
-    _mediaPlayer->play();
 }
 
 void MainWindow::DoHide()
@@ -796,7 +779,7 @@ void MainWindow::showEvent(QShowEvent *event)
     if (_cacheModel.has_value()) {
         PlayAnimation();
     }
-    else if (_isAnimationPlaying) {
+    else if (_wantAnimationPlaying) {
         StopAnimation();
     }
     ControlAutoHideTimer(true);

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -204,9 +204,9 @@ MainWindow::MainWindow(QWidget *parent) : QDialog{parent}
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowFlags(windowFlags() | Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
 
-    Utils::Qt::SetRoundedCorners(this, 30);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAutoFillBackground(false);
     Utils::Qt::SetRoundedCorners(_ui.pushButton, 6);
-    Utils::Qt::SetPaletteColor(this, QPalette::Window, Qt::white);
     Utils::Qt::SetPaletteColor(_ui.deviceLabel, QPalette::WindowText, QColor{94, 94, 94});
 
     connect(qApp, &QGuiApplication::applicationStateChanged, this, &MainWindow::OnAppStateChanged);
@@ -691,6 +691,19 @@ void MainWindow::DoHide()
     _posAnimation.setStartValue(pos());
     _posAnimation.setEndValue(QPoint{x(), screenSize.height()});
     _posAnimation.start();
+}
+
+void MainWindow::paintEvent(QPaintEvent *event)
+{
+    QPainter painter{this};
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    QPainterPath path;
+    path.addRoundedRect(rect(), 30, 30);
+
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(Qt::white);
+    painter.drawPath(path);
 }
 
 void MainWindow::showEvent(QShowEvent *event)

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -21,7 +21,6 @@
 #include <QScreen>
 #include <QPainter>
 #include <QMessageBox>
-
 #include <Config.h>
 #include "../Helper.h"
 #include "../Error.h"
@@ -128,12 +127,24 @@ protected:
 
 //////////////////////////////////////////////////
 
-class VideoWidget : public QVideoWidget
+class AnimationView : public QGraphicsView
 {
     Q_OBJECT
 
 public:
-    using QVideoWidget::QVideoWidget;
+    AnimationView(QWidget *parent = nullptr) : QGraphicsView{parent}
+    {
+        setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+        setFrameShape(QFrame::NoFrame);
+        setAutoFillBackground(false);
+
+        // Make both the view and its viewport transparent
+        setAttribute(Qt::WA_TranslucentBackground);
+        viewport()->setAttribute(Qt::WA_TranslucentBackground);
+        viewport()->setAutoFillBackground(false);
+    }
 
 Q_SIGNALS:
     void Clicked();
@@ -195,7 +206,12 @@ MainWindow::MainWindow(QWidget *parent) : QDialog{parent}
     qRegisterMetaType<Core::AirPods::State>("Core::AirPods::State");
     qRegisterMetaType<Core::Update::ReleaseInfo>("Core::Update::ReleaseInfo");
 
-    _videoWidget = new VideoWidget{this};
+    _videoItem = new QGraphicsVideoItem;
+    _scene = new QGraphicsScene{this};
+    _scene->setBackgroundBrush(Qt::NoBrush);
+    _scene->addItem(_videoItem);
+    _view = new AnimationView{this};
+    _view->setScene(_scene);
     _closeButton = new CloseButton{this};
 
     _ui.setupUi(this);
@@ -212,9 +228,14 @@ MainWindow::MainWindow(QWidget *parent) : QDialog{parent}
     connect(qApp, &QGuiApplication::applicationStateChanged, this, &MainWindow::OnAppStateChanged);
     connect(_ui.pushButton, &QPushButton::clicked, this, &MainWindow::OnButtonClicked);
     connect(&_posAnimation, &QPropertyAnimation::finished, this, &MainWindow::OnPosMoveFinished);
-    connect(_videoWidget, &VideoWidget::Clicked, this, &MainWindow::OnAnimationClicked);
+    connect(_view, &AnimationView::Clicked, this, &MainWindow::OnAnimationClicked);
     connect(_closeButton, &CloseButton::Clicked, this, &MainWindow::DoHide);
     connect(_mediaPlayer, &QMediaPlayer::stateChanged, this, &MainWindow::OnPlayerStateChanged);
+    connect(
+        _mediaPlayer, QOverload<QMediaPlayer::Error>::of(&QMediaPlayer::error), this,
+        &MainWindow::OnPlayerError);
+    connect(
+        _mediaPlayer, &QMediaPlayer::mediaStatusChanged, this, &MainWindow::OnMediaStatusChanged);
 
     connect(this, &MainWindow::UpdateStateSafely, this, &MainWindow::UpdateState);
     connect(this, &MainWindow::AvailableSafely, this, &MainWindow::Available);
@@ -230,17 +251,17 @@ MainWindow::MainWindow(QWidget *parent) : QDialog{parent}
     _posAnimation.setDuration(500);
     _autoHideTimer->callOnTimeout([this] { DoHide(); });
     _mediaPlayer->setMuted(true);
-    _mediaPlayer->setVideoOutput(_videoWidget);
+    _mediaPlayer->setVideoOutput(_videoItem);
 
-    _ui.layoutAnimation->addWidget(_videoWidget);
+    _ui.layoutAnimation->addWidget(_view);
     _ui.layoutPods->addWidget(_leftBattery);
     _ui.layoutPods->addWidget(_rightBattery);
     _ui.layoutCase->addWidget(_caseBattery);
     _ui.layoutClose->addWidget(_closeButton);
 
-    // For getting the correct initial height of `_videoWidget` later
+    // For getting the correct initial height of `_view` later
     _ui.layoutAnimation->activate();
-    _videoWidget->show();
+    _view->show();
 
     Unavailable();
     _updateChecker.Start();
@@ -447,12 +468,20 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
         }
 
         auto aspectRatio = (float)videoSize.width() / (float)videoSize.height();
-        auto widgetWidth = _videoWidget->height() * aspectRatio;
-        _videoWidget->setFixedWidth(widgetWidth);
+        auto viewHeight = _view->height();
+        auto widgetWidth = viewHeight * aspectRatio;
+        _view->setFixedWidth(widgetWidth);
+
+        // Size the video item to fill the view and set the scene rect accordingly
+        _videoItem->setSize(
+            QSizeF{static_cast<qreal>(widgetWidth), static_cast<qreal>(viewHeight)});
+        _scene->setSceneRect(0, 0, static_cast<qreal>(widgetWidth), static_cast<qreal>(viewHeight));
 
         _mediaPlayer->setMedia(QUrl{media});
 
-        PlayAnimation();
+        if (_isVisible) {
+            PlayAnimation();
+        }
     }
 
     _cacheModel = model;
@@ -461,17 +490,24 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
 void MainWindow::PlayAnimation()
 {
     _isAnimationPlaying = true;
-    _mediaPlayer->play();
-    _videoWidget->show();
+    _view->show();
+
+    // Try to play the animation. If play() fails with ResourceError (which can
+    // happen on the very first play when the rendering surface is not yet ready),
+    // OnPlayerError will stop() and set _pendingAnimation, then
+    // OnMediaStatusChanged will retry play() once the media is loaded again.
+    _pendingAnimation = true;
+    TryPlayPendingAnimation();
 }
 
 void MainWindow::StopAnimation()
 {
     // The player will go black after stopping
     // I have no idea about this, so let's hide the widget here as a workaround
-    _videoWidget->hide();
+    _view->hide();
 
     _isAnimationPlaying = false;
+    _pendingAnimation = false;
     _mediaPlayer->stop();
 }
 
@@ -483,8 +519,9 @@ void MainWindow::BindDevice()
     if (devices.empty()) {
         QMessageBox::warning(
             this, Config::ProgramName,
-            QMessageBox::tr("No paired device found.\n"
-                            "You need to pair your AirPods in Windows Bluetooth Settings first."));
+            QMessageBox::tr(
+                "No paired device found.\n"
+                "You need to pair your AirPods in Windows Bluetooth Settings first."));
         return;
     }
 
@@ -673,6 +710,45 @@ void MainWindow::OnPlayerStateChanged(QMediaPlayer::State newState)
     }
 }
 
+void MainWindow::OnPlayerError(QMediaPlayer::Error error)
+{
+    LOG(Error, "QMediaPlayer error: {}", static_cast<int>(error));
+
+    // On the very first play(), QGraphicsVideoItem's rendering surface may not
+    // be ready yet, causing a ResourceError. We need to stop the player first
+    // (to clear the error state), then retry play() via _pendingAnimation.
+    // Temporarily clear _isAnimationPlaying to prevent OnPlayerStateChanged
+    // from re-playing during stop(), and restore it after for the retry.
+    if (error == QMediaPlayer::ResourceError && _isAnimationPlaying) {
+        _isAnimationPlaying = false;
+        _mediaPlayer->stop();
+        _isAnimationPlaying = true;
+        _pendingAnimation = true;
+    }
+}
+
+void MainWindow::OnMediaStatusChanged(QMediaPlayer::MediaStatus status)
+{
+    TryPlayPendingAnimation();
+}
+
+void MainWindow::TryPlayPendingAnimation()
+{
+    if (!_pendingAnimation || !_isAnimationPlaying) {
+        return;
+    }
+
+    if (_mediaPlayer->mediaStatus() != QMediaPlayer::LoadedMedia &&
+        _mediaPlayer->mediaStatus() != QMediaPlayer::BufferedMedia &&
+        _mediaPlayer->mediaStatus() != QMediaPlayer::StalledMedia)
+    {
+        return;
+    }
+
+    _pendingAnimation = false;
+    _mediaPlayer->play();
+}
+
 void MainWindow::DoHide()
 {
     LOG(Trace, "MainWindow: Hide");
@@ -715,7 +791,12 @@ void MainWindow::showEvent(QShowEvent *event)
     }
     _isVisible = true;
 
-    PlayAnimation();
+    if (_cacheModel.has_value()) {
+        PlayAnimation();
+    }
+    else if (_isAnimationPlaying) {
+        StopAnimation();
+    }
     ControlAutoHideTimer(true);
 
     auto screenSize = ApdApplication::primaryScreen()->size();

--- a/Source/Gui/MainWindow.h
+++ b/Source/Gui/MainWindow.h
@@ -116,6 +116,7 @@ private:
 
     void DoHide();
     void showEvent(QShowEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
 
     UTILS_QT_DISABLE_ESC_QUIT(QDialog);
     UTILS_QT_REGISTER_LANGUAGECHANGE(QDialog, [this] {

--- a/Source/Gui/MainWindow.h
+++ b/Source/Gui/MainWindow.h
@@ -22,7 +22,9 @@
 
 #include "ui_MainWindow.h"
 
-#include <QVideoWidget>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QGraphicsVideoItem>
 #include <QMediaPlayer>
 #include <QPropertyAnimation>
 
@@ -35,7 +37,7 @@
 namespace Gui {
 
 class CloseButton;
-class VideoWidget;
+class AnimationView;
 class BatteryInfo;
 
 enum class ButtonAction : uint32_t {
@@ -80,7 +82,9 @@ private:
     Ui::MainWindow _ui;
 
     QPropertyAnimation _posAnimation{this, "pos"};
-    VideoWidget *_videoWidget;
+    QGraphicsScene *_scene;
+    AnimationView *_view;
+    QGraphicsVideoItem *_videoItem;
     QMediaPlayer *_mediaPlayer = new QMediaPlayer{this};
     QTimer *_autoHideTimer = new QTimer{this};
     CloseButton *_closeButton;
@@ -98,6 +102,7 @@ private:
     std::optional<Core::AirPods::State> _cachedState;
     bool _isVisible{false};
     bool _isAnimationPlaying{false};
+    bool _pendingAnimation{false};
 
     void ChangeButtonAction(ButtonAction action);
     void SetAnimation(std::optional<Core::AirPods::Model> model);
@@ -113,6 +118,9 @@ private:
     void OnAnimationClicked();
     void OnButtonClicked();
     void OnPlayerStateChanged(QMediaPlayer::State newState);
+    void OnPlayerError(QMediaPlayer::Error error);
+    void OnMediaStatusChanged(QMediaPlayer::MediaStatus status);
+    void TryPlayPendingAnimation();
 
     void DoHide();
     void showEvent(QShowEvent *event) override;

--- a/Source/Gui/MainWindow.h
+++ b/Source/Gui/MainWindow.h
@@ -119,7 +119,7 @@ private:
     void OnPlayerStateChanged(QMediaPlayer::State newState);
     void OnPlayerError(QMediaPlayer::Error error);
     void OnMediaStatusChanged(QMediaPlayer::MediaStatus status);
-    void MaybeStartPlayback();
+    void TryStartPlayback();
 
     void DoHide();
     void showEvent(QShowEvent *event) override;

--- a/Source/Gui/MainWindow.h
+++ b/Source/Gui/MainWindow.h
@@ -101,8 +101,7 @@ private:
     Status _status{Status::Unavailable};
     std::optional<Core::AirPods::State> _cachedState;
     bool _isVisible{false};
-    bool _isAnimationPlaying{false};
-    bool _pendingAnimation{false};
+    bool _wantAnimationPlaying{false};
 
     void ChangeButtonAction(ButtonAction action);
     void SetAnimation(std::optional<Core::AirPods::Model> model);
@@ -120,7 +119,7 @@ private:
     void OnPlayerStateChanged(QMediaPlayer::State newState);
     void OnPlayerError(QMediaPlayer::Error error);
     void OnMediaStatusChanged(QMediaPlayer::MediaStatus status);
-    void TryPlayPendingAnimation();
+    void MaybeStartPlayback();
 
     void DoHide();
     void showEvent(QShowEvent *event) override;

--- a/Source/Utils.h
+++ b/Source/Utils.h
@@ -67,19 +67,6 @@ namespace Qt {
         base_name::changeEvent(event);                                                             \
     }
 
-// for windows
-inline void SetRoundedCorners(QDialog *widget, qreal radius)
-{
-    QBitmap bmp{widget->size()};
-    QPainter painter{&bmp};
-    bmp.clear();
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(::Qt::black);
-    painter.setBrush(::Qt::black);
-    painter.drawRoundedRect(widget->geometry(), radius, radius, ::Qt::AbsoluteSize);
-    widget->setMask(bmp);
-}
-
 // for widgets
 inline void SetRoundedCorners(QWidget *widget, qreal radius)
 {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "airpods-desktop",
-  "version-string": "0.4.1",
+  "version-string": "0.4.2",
   "dependencies": [
     {
       "name": "cpr",


### PR DESCRIPTION
Closes #133.

**Problem**: Window rounded corners show visible aliasing due to `QBitmap` + `setMask()` being 1-bit without alpha blending.

**Solution**: Use `Qt::WA_TranslucentBackground` with custom `paintEvent` drawing antialiased rounded rectangle via `QPainterPath`.

**Side effects fixed**:
- `QVideoWidget` breaks under translucent background -> replaced with `QGraphicsVideoItem`
- First-play `ResourceError` from uninitialized render surface -> fixed with event-driven playback state machine (`_wantAnimationPlaying` + `TryStartPlayback`)

**Testing**: Local build passed. Tested with personal AirPods - working correctly.
<img width="300" height="300" alt="2224fe878e0b897b64874a3020b7f29c" src="https://github.com/user-attachments/assets/e204f255-a6da-4d46-a27b-7945ab7986c5" />