### PR TITLE
Add AirPods Max (2024, USB-C) support

### DIFF
--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -470,8 +470,10 @@ void Manager::OnStateChanged(Details::StateManager::UpdateEvent updateEvent)
     const auto &oldState = updateEvent.oldState;
     auto &newState = updateEvent.newState;
 
+    // AirPods Max 2 Bluetooth name is "AirPods Max" same as original; use model string to distinguish.
+    bool useModelName = _deviceName.isEmpty() || newState.model == Model::AirPods_Max_2;
     newState.displayName =
-        _deviceName.isEmpty() ? Helper::ToString(newState.model) : _deviceName.remove(" - Find My");
+        useModelName ? Helper::ToString(newState.model) : _deviceName.remove(" - Find My");
 
     ApdApp->GetMainWindow()->UpdateStateSafely(newState);
 

--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -62,6 +62,8 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
         return Core::AirPods::Model::AirPods_Pro_3;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
+    case 0x201F:
+        return Core::AirPods::Model::AirPods_Max_2;
         // case 0x2003:
         //    return Core::AirPods::Model::Powerbeats_3;
         // case 0x2005:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -74,6 +74,7 @@ enum class Model : uint32_t {
     AirPods_4_ANC,
     AirPods_Pro_3,
     AirPods_Max,
+    AirPods_Max_2,
     Powerbeats_3,
     Beats_X,
     Beats_Solo3,
@@ -110,6 +111,8 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro 3";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
+    case Core::AirPods::Model::AirPods_Max_2:
+        return "AirPods Max (2024)";
     case Core::AirPods::Model::Powerbeats_3:
         return "Powerbeats 3";
     case Core::AirPods::Model::Beats_X:

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -430,6 +430,7 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
             videoSize = QSize{900, 450};
             break;
         case Core::AirPods::Model::AirPods_Max:
+        case Core::AirPods::Model::AirPods_Max_2:
             media = "qrc:/Resource/Video/AirPods_Max.avi";
             videoSize = QSize{600, 650};
             break;


### PR DESCRIPTION
Adds recognition for the AirPods Max released in November 2024 (USB-C model, product ID 0x201F).

Changes:
- `Source/Core/Base.h`: add `AirPods_Max_2` to the `Model` enum and its display name `"AirPods Max (2024)"`
- `Source/Core/AppleCP.cpp`: map PID `0x201F` to `AirPods_Max_2`
- `Source/Core/AirPods.cpp`: use the model string as the display name for AirPods Max 2, since its Bluetooth device name ("AirPods Max") is identical to the original model
- `Source/Gui/MainWindow.cpp`: route AirPods Max 2 to the existing AirPods Max animation

Tested with AirPods Max (USB-C) on Windows 11. Battery and connection status display correctly.
<img width="243" height="236" alt="2026-06-10 20_31_46-AirPodsDesktop information" src="https://github.com/user-attachments/assets/bb6e5a8c-440f-4e3f-8ef9-871b985936af" />

