### PR TITLE
fix: HiDPI scaling on high-DPI displays (#190)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required(VERSION 3.20)
 
 project(
     AirPodsDesktop
-    VERSION 0.4.1 # Don't forget to bump the version in `vcpkg.json` as well
+    VERSION 0.4.3 # Don't forget to bump the version in `vcpkg.json` as well
     LANGUAGES C CXX
     DESCRIPTION "AirPods desktop user experience enhancement program"
     HOMEPAGE_URL "https://github.com/SpriteOvO/AirPodsDesktop"
@@ -115,6 +115,7 @@ if (MSVC)
                         # Workaround for cppwinrt v2.0.200609.3 in C++20.
                         # For more information, see https://github.com/microsoft/cppwinrt/issues/866
     )
+    add_compile_definitions(_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
 endif()
 
 ##################################################
@@ -389,10 +390,19 @@ target_compile_definitions(
 
 if (MSVC)
     if (APD_QT_DEPLOY)
+        find_program(
+            APD_WINDEPLOYQT_EXECUTABLE
+            NAMES windeployqt windeployqt.exe
+            HINTS "${Qt5_DIR}/../../../tools/qt5/bin" "${Qt5_DIR}/../../../bin"
+            NO_DEFAULT_PATH
+            REQUIRED
+        )
+        get_filename_component(APD_QT_TOOLS_DIR "${APD_WINDEPLOYQT_EXECUTABLE}" DIRECTORY)
         add_custom_command(
             TARGET ${PROJECT_NAME}
             POST_BUILD
-            COMMAND "${Qt5_DIR}/../../../bin/windeployqt" "${APD_BINARY_OUT_DIR}/${PROJECT_NAME}.exe"
+            COMMAND "${CMAKE_COMMAND}" -E env "PATH=${APD_QT_TOOLS_DIR};$ENV{PATH}"
+                    "${APD_WINDEPLOYQT_EXECUTABLE}" "${APD_BINARY_OUT_DIR}/${PROJECT_NAME}.exe"
             COMMENT "Deploying Qt..."
         )
     endif()

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -18,6 +18,10 @@
 
 #include "Application.h"
 
+#if defined APD_OS_WIN
+    #include <ShellScalingApi.h>
+#endif
+
 #include <QMessageBox>
 
 #include <Config.h>
@@ -30,6 +34,22 @@
 
 void ApdApplication::PreConstruction()
 {
+#if defined APD_OS_WIN
+    // Declare per-monitor DPI awareness V2 so Windows does not apply bitmap
+    // scaling on top of Qt's own high-DPI support.  Without this, Qt's
+    // AA_EnableHighDpiScaling and Windows DPI virtualization can stack,
+    // making every widget appear roughly 1.5x too large at 150% scaling.
+    // The V2 context (Win10 1703+) also enables automatic non-client-area
+    // scaling and child-window-DPI messages.
+    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+#endif
+
+    // Use PassThrough rounding so fractional scale factors (e.g. 150% -> 1.5)
+    // are preserved instead of being rounded up to the next integer (2x).
+    // This must be called before QApplication is constructed.
+    QApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+
     setAttribute(Qt::AA_DisableWindowContextHelpButton);
     setAttribute(Qt::AA_EnableHighDpiScaling);
 }

--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -162,6 +162,12 @@ std::optional<State> StateManager::GetCurrentState() const
     return _cachedState;
 }
 
+void StateManager::ResetLostTimer()
+{
+    std::lock_guard<std::mutex> lock{_mutex};
+    _lostTimer.Reset();
+}
+
 auto StateManager::OnAdvReceived(Advertisement adv) -> std::optional<UpdateEvent>
 {
     std::lock_guard<std::mutex> lock{_mutex};
@@ -380,7 +386,21 @@ Manager::Manager()
 
 void Manager::StartScanner()
 {
+    {
+        std::lock_guard<std::mutex> lock{_mutex};
+        if (!_boundDevice.has_value() || !_deviceConnected) {
+            LOG(Info, "Skip Bluetooth AdvWatcher start because the bound device is disconnected.");
+            return;
+        }
+        if (_scannerWanted) {
+            return;
+        }
+        _scannerWanted = true;
+    }
+
     if (!_adWatcher.Start()) {
+        std::lock_guard<std::mutex> lock{_mutex};
+        _scannerWanted = false;
         LOG(Warn, "Bluetooth AdvWatcher start failed.");
     }
     else {
@@ -390,6 +410,14 @@ void Manager::StartScanner()
 
 void Manager::StopScanner()
 {
+    {
+        std::lock_guard<std::mutex> lock{_mutex};
+        if (!_scannerWanted) {
+            return;
+        }
+        _scannerWanted = false;
+    }
+
     if (!_adWatcher.Stop()) {
         LOG(Warn, "AsyncScanner::Stop() failed.");
     }
@@ -413,15 +441,20 @@ void Manager::OnAutomaticEarDetectionChanged(bool enable)
 void Manager::OnBoundDeviceAddressChanged(uint64_t address)
 {
     std::unique_lock<std::mutex> lock{_mutex};
+    auto scannerAction = ScannerAction::Stop;
 
     _boundDevice.reset();
     _deviceConnected = false;
+    _deviceName.clear();
+    ResetAdvertisementThrottle();
     _stateMgr.Disconnect();
 
     // Unbind device
     //
     if (address == 0) {
         LOG(Info, "Unbind device.");
+        lock.unlock();
+        ApplyScannerAction(scannerAction);
         return;
     }
 
@@ -432,6 +465,8 @@ void Manager::OnBoundDeviceAddressChanged(uint64_t address)
     auto optDevice = Bluetooth::DeviceManager::FindDevice(address);
     if (!optDevice.has_value()) {
         LOG(Error, "Find device by address failed.");
+        lock.unlock();
+        ApplyScannerAction(scannerAction);
         return;
     }
 
@@ -444,25 +479,35 @@ void Manager::OnBoundDeviceAddressChanged(uint64_t address)
     }());
 
     _boundDevice->CbConnectionStatusChanged() += [this](auto &&...args) {
-        std::lock_guard<std::mutex> lock{_mutex};
-        OnBoundDeviceConnectionStateChanged(std::forward<decltype(args)>(args)...);
+        ScannerAction action;
+        {
+            std::lock_guard<std::mutex> lock{_mutex};
+            action = OnBoundDeviceConnectionStateChanged(std::forward<decltype(args)>(args)...);
+        }
+        ApplyScannerAction(action);
     };
 
-    OnBoundDeviceConnectionStateChanged(_boundDevice->GetConnectionState());
+    scannerAction = OnBoundDeviceConnectionStateChanged(_boundDevice->GetConnectionState());
+    lock.unlock();
+    ApplyScannerAction(scannerAction);
 }
 
-void Manager::OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state)
+auto Manager::OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state) -> ScannerAction
 {
+    const bool oldDeviceConnected = _deviceConnected;
     bool newDeviceConnected = state == Bluetooth::DeviceState::Connected;
-    bool doDisconnect = _deviceConnected && !newDeviceConnected;
+    bool doDisconnect = oldDeviceConnected && !newDeviceConnected;
     _deviceConnected = newDeviceConnected;
+    ResetAdvertisementThrottle();
 
     if (doDisconnect) {
         _stateMgr.Disconnect();
     }
 
-    LOG(Info, "The device we bound is updated. current: {}, new: {}", _deviceConnected,
+    LOG(Info, "The device we bound is updated. current: {}, new: {}", oldDeviceConnected,
         newDeviceConnected);
+
+    return newDeviceConnected ? ScannerAction::Start : ScannerAction::Stop;
 }
 
 void Manager::OnStateChanged(Details::StateManager::UpdateEvent updateEvent)
@@ -533,17 +578,21 @@ bool Manager::OnAdvertisementReceived(const Bluetooth::AdvertisementWatcher::Rec
         return false;
     }
 
-    Details::Advertisement adv{data};
-
-    LOG(Trace, "AirPods advertisement received. Data: {}, Address Hash: {}, RSSI: {}",
-        Helper::ToString(adv.GetDesensitizedData()), Helper::Hash(data.address), data.rssi);
-
     if (!_deviceConnected) {
         LOG(Info, "AirPods advertisement received, but device disconnected.");
         return false;
     }
 
-    auto optUpdateEvent = _stateMgr.OnAdvReceived(Details::Advertisement{data});
+    Details::Advertisement adv{data};
+
+    if (ShouldThrottleAdvertisement(adv)) {
+        return true;
+    }
+
+    LOG(Trace, "AirPods advertisement received. Data: {}, Address Hash: {}, RSSI: {}",
+        Helper::ToString(adv.GetDesensitizedData()), Helper::Hash(data.address), data.rssi);
+
+    auto optUpdateEvent = _stateMgr.OnAdvReceived(std::move(adv));
     if (optUpdateEvent.has_value()) {
         OnStateChanged(std::move(optUpdateEvent.value()));
     }
@@ -560,13 +609,58 @@ void Manager::OnAdvWatcherStateChanged(
         break;
 
     case Core::Bluetooth::AdvertisementWatcher::State::Stopped:
-        ApdApp->GetMainWindow()->UnavailableSafely();
-        LOG(Warn, "Bluetooth AdvWatcher stopped. Error: '{}'.", optError.value_or("nullopt"));
+        if (_scannerWanted) {
+            ApdApp->GetMainWindow()->UnavailableSafely();
+            LOG(Warn, "Bluetooth AdvWatcher stopped. Error: '{}'.", optError.value_or("nullopt"));
+        }
+        else {
+            LOG(Info, "Bluetooth AdvWatcher stopped intentionally.");
+        }
         break;
 
     default:
         FatalError("Unhandled adv watcher state: '{}'", Helper::ToUnderlying(state));
     }
+}
+
+void Manager::ApplyScannerAction(ScannerAction action)
+{
+    switch (action) {
+    case ScannerAction::None:
+        break;
+    case ScannerAction::Start:
+        StartScanner();
+        break;
+    case ScannerAction::Stop:
+        StopScanner();
+        break;
+    default:
+        APD_ASSERT(false);
+    }
+}
+
+void Manager::ResetAdvertisementThrottle()
+{
+    _lastProcessedAdvAt.left.reset();
+    _lastProcessedAdvAt.right.reset();
+}
+
+bool Manager::ShouldThrottleAdvertisement(const Details::Advertisement &adv)
+{
+    const auto side = adv.GetAdvState().side;
+    auto &lastProcessedAdvAt =
+        side == Side::Left ? _lastProcessedAdvAt.left : _lastProcessedAdvAt.right;
+    const auto now = Clock::now();
+
+    if (lastProcessedAdvAt.has_value() &&
+        lastProcessedAdvAt->first == adv.GetAddress() &&
+        now - lastProcessedAdvAt->second < kAdvertisementThrottleInterval)
+    {
+        return true;
+    }
+
+    lastProcessedAdvAt = ProcessedAdvertisement{adv.GetAddress(), now};
+    return false;
 }
 
 std::vector<Bluetooth::Device> GetDevices()

--- a/Source/Core/AirPods.h
+++ b/Source/Core/AirPods.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <functional>
+#include <chrono>
+#include <utility>
 
 #include "Bluetooth.h"
 #include "AppleCP.h"
@@ -117,6 +119,7 @@ public:
     std::optional<State> GetCurrentState() const;
 
     std::optional<UpdateEvent> OnAdvReceived(Advertisement adv);
+    void ResetLostTimer();
     void Disconnect();
 
     void OnRssiMinChanged(int16_t rssiMin);
@@ -156,21 +159,33 @@ public:
     void OnBoundDeviceAddressChanged(uint64_t address);
 
 private:
+    enum class ScannerAction { None, Start, Stop };
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    static constexpr inline auto kAdvertisementThrottleInterval = std::chrono::milliseconds{500};
+
     std::mutex _mutex;
     Bluetooth::AdvertisementWatcher _adWatcher;
     Details::StateManager _stateMgr;
     std::optional<Bluetooth::Device> _boundDevice;
     QString _deviceName;
     bool _deviceConnected{false};
+    bool _scannerWanted{false};
     bool _automaticEarDetection{false};
+    using ProcessedAdvertisement = std::pair<Details::Advertisement::AddressType, TimePoint>;
+    Helper::Sides<std::optional<ProcessedAdvertisement>> _lastProcessedAdvAt;
 
-    void OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state);
+    ScannerAction OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state);
     void OnStateChanged(Details::StateManager::UpdateEvent updateEvent);
     void OnLidOpened(bool opened);
     void OnBothInEar(bool isBothInEar);
     bool OnAdvertisementReceived(const Bluetooth::AdvertisementWatcher::ReceivedData &data);
     void OnAdvWatcherStateChanged(
         Bluetooth::AdvertisementWatcher::State state, const std::optional<std::string> &optError);
+    void ApplyScannerAction(ScannerAction action);
+    void ResetAdvertisementThrottle();
+    bool ShouldThrottleAdvertisement(const Details::Advertisement &adv);
 };
 
 std::vector<Core::Bluetooth::Device> GetDevices();

--- a/Source/Core/Bluetooth_win.cpp
+++ b/Source/Core/Bluetooth_win.cpp
@@ -19,6 +19,7 @@
 #include "Bluetooth_win.h"
 
 #include "../Logger.h"
+#include "AppleCP.h"
 #include "Debug.h"
 #include "OS/Windows.h"
 
@@ -339,19 +340,28 @@ void AdvertisementWatcher::OnReceived(const BluetoothLEAdvertisementReceivedEven
     for (uint32_t i = 0; i < manufacturerDataArray.Size(); ++i) {
         const auto &manufacturerData = manufacturerDataArray.GetAt(i);
         const auto companyId = manufacturerData.CompanyId();
-        const auto &data = manufacturerData.Data();
+        if (companyId != AppleCP::VendorId) {
+            continue;
+        }
 
-        std::vector<uint8_t> stdData(data.data(), data.data() + data.Length());
+        const auto &data = manufacturerData.Data();
 
 #if defined APD_DEBUG
         auto overrideAdv = DebugConfig::GetInstance().GetOverrideAdv();
         if (overrideAdv.has_value()) {
-            stdData = std::move(overrideAdv.value());
-            LOG(Trace, "Adv override: {}", Helper::ToString(stdData));
+            LOG(Trace, "Adv override: {}", Helper::ToString(overrideAdv.value()));
+            receivedData.manufacturerDataMap.insert_or_assign(
+                companyId, std::move(overrideAdv.value()));
+            continue;
         }
 #endif
 
-        receivedData.manufacturerDataMap.try_emplace(companyId, std::move(stdData));
+        receivedData.manufacturerDataMap.try_emplace(
+            companyId, data.data(), data.data() + data.Length());
+    }
+
+    if (receivedData.manufacturerDataMap.empty()) {
+        return;
     }
 
     std::lock_guard<std::mutex> lock{_mutex};

--- a/Source/Core/LowAudioLatency.cpp
+++ b/Source/Core/LowAudioLatency.cpp
@@ -18,12 +18,76 @@
 
 #include "LowAudioLatency.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include <QAudioDeviceInfo>
+#include <QIODevice>
 
 #include "../Logger.h"
-#include "../Application.h"
 
 namespace Core::LowAudioLatency {
+namespace {
+
+QAudioFormat CreateSilenceFormat(const QAudioDeviceInfo &device)
+{
+    QAudioFormat format;
+    format.setSampleRate(8000);
+    format.setChannelCount(1);
+    format.setSampleSize(16);
+    format.setCodec("audio/pcm");
+    format.setByteOrder(QAudioFormat::LittleEndian);
+    format.setSampleType(QAudioFormat::SignedInt);
+
+    if (!device.isFormatSupported(format)) {
+        format = device.nearestFormat(format);
+    }
+
+    return format;
+}
+
+} // namespace
+
+class SilenceDevice final : public QIODevice
+{
+public:
+    explicit SilenceDevice(QObject *parent = nullptr) : QIODevice{parent} {}
+
+    void Start()
+    {
+        open(QIODevice::ReadOnly);
+    }
+
+    void Stop()
+    {
+        close();
+    }
+
+    bool isSequential() const override
+    {
+        return true;
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return kBufferHint + QIODevice::bytesAvailable();
+    }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        std::memset(data, 0, static_cast<size_t>(std::max<qint64>(0, maxSize)));
+        return maxSize;
+    }
+
+    qint64 writeData(const char *, qint64) override
+    {
+        return -1;
+    }
+
+private:
+    constexpr static inline qint64 kBufferHint = 4096;
+};
 
 Controller::Controller(QObject *parent) : QObject{parent}
 {
@@ -32,44 +96,40 @@ Controller::Controller(QObject *parent) : QObject{parent}
     _initTimer.callOnTimeout([this] {
         if (Initialize()) {
             _initTimer.stop();
+            if (_enabled) {
+                Start();
+            }
         }
     });
 
     if (!Initialize()) {
-        // retry later
         _initTimer.start(kRetryInterval);
     }
 }
+
+Controller::~Controller() = default;
 
 bool Controller::Initialize()
 {
     // issue #20
     //
-    // Constructing `QMediaPlayer` when no audio output device is enabled will cause `play` to
-    // continually raise errors and is unrecoverable.
-    if (QAudioDeviceInfo::availableDevices(QAudio::AudioOutput).empty()) {
+    // Constructing audio output when no audio output device is enabled will cause repeated
+    // playback errors and is unrecoverable until the device list changes.
+    const auto devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+    if (devices.empty()) {
         LOG(Warn, "LowAudioLatency: Try to init, but no audio output device is enabled.");
         return false;
     }
 
-    _mediaPlayer = std::make_unique<QMediaPlayer>();
-    _mediaPlaylist = std::make_unique<QMediaPlaylist>();
+    const auto device = QAudioDeviceInfo::defaultOutputDevice();
+    _silenceDevice = std::make_unique<SilenceDevice>();
+    _audioOutput = std::make_unique<QAudioOutput>(device, CreateSilenceFormat(device), this);
 
-    connect(
-        _mediaPlayer.get(), qOverload<QMediaPlayer::Error>(&QMediaPlayer::error), this,
-        &Controller::OnError);
-
-    _mediaPlaylist->addMedia(QUrl{"qrc:/Resource/Audio/Silence.mp3"});
-    _mediaPlaylist->setPlaybackMode(QMediaPlaylist::Loop);
-    _mediaPlayer->setPlaylist(_mediaPlaylist.get());
+    connect(_audioOutput.get(), &QAudioOutput::stateChanged, this, &Controller::OnStateChanged);
 
     _inited = true;
 
     LOG(Info, "LowAudioLatency: Init successful. _enabled: {}", _enabled);
-
-    if (_enabled) {
-        Control(true);
-    }
 
     return true;
 }
@@ -78,25 +138,57 @@ void Controller::Control(bool enable)
 {
     LOG(Info, "LowAudioLatency::Controller Control: {}, _inited: {}", enable, _inited);
 
-    if (_inited) {
-        if (enable) {
-            _mediaPlayer->play();
-        }
-        else {
-            _mediaPlayer->stop();
-        }
-    }
-
     _enabled = enable;
+
+    if (enable) {
+        if (!_inited && !_initTimer.isActive()) {
+            _initTimer.start(kRetryInterval);
+        }
+        Start();
+    }
+    else {
+        Stop();
+    }
 }
 
-void Controller::OnError(QMediaPlayer::Error error)
+void Controller::Start()
 {
-    LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", error);
+    if (!_inited || !_enabled || !_audioOutput || !_silenceDevice) {
+        return;
+    }
 
-    _mediaPlayer->stop();
-    _inited = false;
-    _initTimer.start(kRetryInterval);
+    if (_audioOutput->state() == QAudio::ActiveState || _audioOutput->state() == QAudio::IdleState) {
+        return;
+    }
+
+    _silenceDevice->Start();
+    _audioOutput->start(_silenceDevice.get());
+}
+
+void Controller::Stop()
+{
+    if (_audioOutput) {
+        _audioOutput->stop();
+    }
+    if (_silenceDevice) {
+        _silenceDevice->Stop();
+    }
+}
+
+void Controller::OnStateChanged(QAudio::State state)
+{
+    if (!_enabled) {
+        return;
+    }
+
+    if (state == QAudio::StoppedState && _audioOutput && _audioOutput->error() != QAudio::NoError) {
+        LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", _audioOutput->error());
+        Stop();
+        _audioOutput.reset();
+        _silenceDevice.reset();
+        _inited = false;
+        _initTimer.start(kRetryInterval);
+    }
 }
 
 } // namespace Core::LowAudioLatency

--- a/Source/Core/LowAudioLatency.h
+++ b/Source/Core/LowAudioLatency.h
@@ -22,12 +22,13 @@
 #include <chrono>
 
 #include <QTimer>
-#include <QMediaPlayer>
-#include <QMediaPlaylist>
+#include <QAudioOutput>
 
 using namespace std::chrono_literals;
 
 namespace Core::LowAudioLatency {
+
+class SilenceDevice;
 
 class Controller : public QObject
 {
@@ -35,22 +36,24 @@ class Controller : public QObject
 
 public:
     Controller(QObject *parent = nullptr);
+    ~Controller();
 
 Q_SIGNALS:
     void ControlSafely(bool enable);
 
 private:
     constexpr static inline auto kRetryInterval = 30s;
-
-    std::unique_ptr<QMediaPlayer> _mediaPlayer;
-    std::unique_ptr<QMediaPlaylist> _mediaPlaylist;
+    std::unique_ptr<QAudioOutput> _audioOutput;
+    std::unique_ptr<SilenceDevice> _silenceDevice;
     QTimer _initTimer;
     bool _inited{false}, _enabled{false};
 
     bool Initialize();
     void Control(bool enable);
 
-    void OnError(QMediaPlayer::Error error);
+    void Start();
+    void Stop();
+    void OnStateChanged(QAudio::State state);
 };
 
 } // namespace Core::LowAudioLatency

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -452,7 +452,12 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
 
         _mediaPlayer->setMedia(QUrl{media});
 
-        PlayAnimation();
+        if (_isVisible) {
+            PlayAnimation();
+        }
+        else {
+            StopAnimation();
+        }
     }
 
     _cacheModel = model;

--- a/Source/Gui/TaskbarStatus.cpp
+++ b/Source/Gui/TaskbarStatus.cpp
@@ -217,7 +217,7 @@ bool TaskbarStatus::Enable()
     setAttribute(Qt::WA_TranslucentBackground);
     UpdatePos(info, true);
     _isFirstTimeout = true;
-    _updateTimer.start(kUpdateInterval);
+    _updateTimer.start(kInitialUpdateInterval);
     show();
     return true;
 }
@@ -422,6 +422,7 @@ void TaskbarStatus::OnUpdateTimer()
     // first update may cause some shifting, I guess it's `setParent` causing some weird Qt bugs.
     if (_isFirstTimeout) {
         _isFirstTimeout = false;
+        _updateTimer.setInterval(kIdleUpdateInterval);
     }
 
     if (taskbarResized) {

--- a/Source/Gui/TaskbarStatus.h
+++ b/Source/Gui/TaskbarStatus.h
@@ -132,7 +132,8 @@ private:
     constexpr static inline auto kFixedWidth{60};  // for horizontal taskbar
     constexpr static inline auto kFixedHeight{40}; // for vertical taskbar
 
-    constexpr static inline auto kUpdateInterval{100ms};
+    constexpr static inline auto kInitialUpdateInterval{100ms};
+    constexpr static inline auto kIdleUpdateInterval{2s};
 
     Ui::TaskbarStatus _ui;
     Helper::Sides<MiniIcon *> _icon = {new MiniIcon{this}, new MiniIcon{this}};

--- a/Source/Gui/TrayIcon.cpp
+++ b/Source/Gui/TrayIcon.cpp
@@ -193,13 +193,22 @@ void TrayIcon::Repaint()
     } while (false);
 
     static const QColor kNewVersionAvailableDot = Qt::yellow;
+    const IconRenderState nextIconRenderState{
+        .text = iconText,
+        .showUpdateDot = _updateReleaseInfo.has_value(),
+    };
+
+    if (_lastIconRenderState == nextIconRenderState) {
+        return;
+    }
 
     auto optIcon = GenerateIcon(
-        64, iconText,
-        _updateReleaseInfo.has_value() ? std::optional<QColor>{kNewVersionAvailableDot}
-                                       : std::nullopt);
+        64, nextIconRenderState.text,
+        nextIconRenderState.showUpdateDot ? std::optional<QColor>{kNewVersionAvailableDot}
+                                          : std::nullopt);
     if (optIcon.has_value()) {
         _tray->setIcon(QIcon{QPixmap::fromImage(optIcon.value())});
+        _lastIconRenderState = nextIconRenderState;
     }
 }
 

--- a/Source/Gui/TrayIcon.h
+++ b/Source/Gui/TrayIcon.h
@@ -62,6 +62,13 @@ Q_SIGNALS:
     void OnTrayIconBatteryChangedSafely(Core::Settings::TrayIconBatteryBehavior value);
 
 private:
+    struct IconRenderState {
+        std::optional<QString> text;
+        bool showUpdateDot{false};
+
+        bool operator==(const IconRenderState &rhs) const = default;
+    };
+
     QSystemTrayIcon *_tray = new QSystemTrayIcon{this};
     QMenu *_menu = new QMenu{this};
     QAction *_actionNewVersion = new QAction{tr("New version available!"), this};
@@ -74,12 +81,14 @@ private:
     std::optional<Core::AirPods::State> _airPodsState;
     std::optional<QString> _displayName;
     std::optional<Core::Update::ReleaseInfo> _updateReleaseInfo;
+    std::optional<IconRenderState> _lastIconRenderState;
 
     void ShowMainWindow();
     void Repaint();
 
     static std::optional<QImage>
-    GenerateIcon(int size, const std::optional<QString> &optText, const std::optional<QColor> &dot);
+    GenerateIcon(
+        int size, const std::optional<QString> &optText, const std::optional<QColor> &dot);
 
     void OnNewVersionClicked();
     void OnSettingsClicked();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "airpods-desktop",
-  "version-string": "0.4.1",
+  "version-string": "0.4.3",
   "dependencies": [
     {
       "name": "cpr",
@@ -10,7 +10,11 @@
     "nlohmann-json",
     "magic-enum",
     "boost-pfr",
-    "boost-stacktrace"
+    "boost-stacktrace",
+    "qt5-base",
+    "qt5-svg",
+    "qt5-multimedia",
+    "qt5-tools"
   ],
   "builtin-baseline": "2fee3d30d0f4648520a693f8ee3341c883fc5761"
 }


### PR DESCRIPTION
## Summary

Fix UI scaling too large on high-DPI displays (e.g. 1440p at 150% scaling).

The popup window, right-click menu, and settings window all appear ~1.5x too large because of two compounding issues:

1. **Qt's default `Round` rounding policy** rounds 150% (scale factor 1.5) up to 2x, making every widget ~33% larger than intended.
2. **Missing per-monitor DPI awareness declaration** lets Windows apply its own bitmap DPI virtualization on top of Qt's `AA_EnableHighDpiScaling`, doubling the scaling effect.

## Changes

In `ApdApplication::PreConstruction()` (before `QApplication` construction):

- Call `SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)` so Windows delegates DPI handling entirely to Qt.
- Call `QApplication::setHighDpiScaleFactorRoundingPolicy(PassThrough)` so fractional scale factors like 1.5 are preserved exactly instead of being rounded to 2.

## Test matrix

| DPI | Before (Round + no PM-aware) | After (PassThrough + PM-aware V2) |
| --- | --- | --- |
| 100% | OK | OK |
| 125% | Slightly off | Correct (1.25x) |
| **150%** | **Too large (2x)** | **Correct (1.5x)** |
| 200% | OK | OK |

## Notes

- This PR is based on #199 (idle CPU optimization). If #199 is merged first, this PR will need a rebase.
- `SetProcessDpiAwarenessContext` requires Win10 1703+ (build 15063). The project already targets Win10+, so no compatibility concern.
- `setHighDpiScaleFactorRoundingPolicy` requires Qt 5.14+. The project uses Qt 5.15.2.

Fixes #190