### PR TITLE
Optimize idle performance and low-latency audio UX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(
 
 project(
     AirPodsDesktop
-    VERSION 0.5.0 # Don't forget to bump the version in `vcpkg.json` as well
+    VERSION 0.5.1 # Don't forget to bump the version in `vcpkg.json` as well
     LANGUAGES C CXX
     DESCRIPTION "AirPods desktop user experience enhancement program"
     HOMEPAGE_URL "https://github.com/${APD_GITHUB_OWNER}/${APD_GITHUB_REPOSITORY}"

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -109,7 +109,7 @@ void ApdApplication::FirstTimeUse()
             tr("Do you want to enable the \"low audio latency\" feature?\n"
                "\n%1")
                 .arg(constMetaFields.low_audio_latency.Description()),
-            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes;
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes;
 
     Core::Settings::Save(std::move(current));
 
@@ -234,6 +234,9 @@ void ApdApplication::ConnectAirPodsManager()
                 _taskbarStatus->Unavailable();
             }
         });
+    connect(
+        manager, &Core::AirPods::Manager::DeviceConnectionChanged, _lowAudioLatencyController.get(),
+        &Core::LowAudioLatency::Controller::SetDeviceConnectedSafely);
     connect(manager, &Core::AirPods::Manager::LidToggled, mainWindow, [mainWindow](bool opened) {
         if (opened) {
             emit mainWindow->ShowSafely();
@@ -343,6 +346,7 @@ void ApdApplication::OnAutoRunChanged(bool enable)
 void ApdApplication::OnLowAudioLatencyChanged(bool enable)
 {
     _lowAudioLatencyController->ControlSafely(enable);
+    _trayIcon->OnLowAudioLatencyChangedSafely(enable);
 }
 
 void ApdApplication::OnAutomaticEarDetectionChanged(bool enable)

--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -57,7 +57,21 @@ Manager::~Manager()
 
 void Manager::StartScanner()
 {
+    {
+        std::lock_guard<std::mutex> lock{_mutex};
+        if (!_boundDevice.has_value() || !_deviceConnected) {
+            LOG(Info, "Skip Bluetooth AdvWatcher start because the bound device is disconnected.");
+            return;
+        }
+        if (_scannerWanted) {
+            return;
+        }
+        _scannerWanted = true;
+    }
+
     if (!_adWatcher.Start()) {
+        std::lock_guard<std::mutex> lock{_mutex};
+        _scannerWanted = false;
         LOG(Warn, "Bluetooth AdvWatcher start failed.");
     }
     else {
@@ -67,6 +81,14 @@ void Manager::StartScanner()
 
 void Manager::StopScanner()
 {
+    {
+        std::lock_guard<std::mutex> lock{_mutex};
+        if (!_scannerWanted) {
+            return;
+        }
+        _scannerWanted = false;
+    }
+
     if (!_adWatcher.Stop()) {
         LOG(Warn, "AsyncScanner::Stop() failed.");
     }
@@ -101,6 +123,8 @@ void Manager::OnBoundDeviceAddressChanged(uint64_t address)
     _boundModel = Model::Unknown;
     _deviceConnected = false;
     _stateMgr.Disconnect();
+    emit DeviceConnectionChanged(false);
+    QMetaObject::invokeMethod(this, [this] { StopScanner(); }, Qt::QueuedConnection);
 
     if (address == 0) {
         LOG(Info, "Unbind device.");
@@ -158,15 +182,29 @@ void Manager::CompleteBoundDeviceLookup(uint64_t address, std::optional<Bluetoot
 
 void Manager::OnBoundDeviceConnectionStateChanged(Bluetooth::DeviceState state)
 {
+    const bool oldDeviceConnected = _deviceConnected;
     bool newDeviceConnected = state == Bluetooth::DeviceState::Connected;
-    bool doDisconnect = _deviceConnected && !newDeviceConnected;
+    bool doDisconnect = oldDeviceConnected && !newDeviceConnected;
     _deviceConnected = newDeviceConnected;
+    emit DeviceConnectionChanged(newDeviceConnected);
+
+    QMetaObject::invokeMethod(
+        this,
+        [this, newDeviceConnected] {
+            if (newDeviceConnected) {
+                StartScanner();
+            }
+            else {
+                StopScanner();
+            }
+        },
+        Qt::QueuedConnection);
 
     if (doDisconnect) {
         _stateMgr.Disconnect();
     }
 
-    LOG(Info, "The device we bound is updated. current: {}, new: {}", _deviceConnected,
+    LOG(Info, "The device we bound is updated. current: {}, new: {}", oldDeviceConnected,
         newDeviceConnected);
 }
 
@@ -230,9 +268,6 @@ bool Manager::OnAdvertisementReceived(const Bluetooth::AdvertisementWatcher::Rec
 
     Details::Advertisement adv{data};
 
-    LOG(Trace, "AirPods advertisement received. Data: {}, Address Hash: {}, RSSI: {}",
-        Helper::ToString(adv.GetDesensitizedData()), Helper::Hash(data.address), data.rssi);
-
     if (!_deviceConnected) {
         LOG(Info, "AirPods advertisement received, but device disconnected.");
         return false;
@@ -242,6 +277,9 @@ bool Manager::OnAdvertisementReceived(const Bluetooth::AdvertisementWatcher::Rec
         LOG(Trace, "Ignore advertisement for a model other than the bound device.");
         return false;
     }
+
+    LOG(Trace, "AirPods advertisement received. Data: {}, Address Hash: {}, RSSI: {}",
+        Helper::ToString(adv.GetDesensitizedData()), Helper::Hash(data.address), data.rssi);
 
     auto optUpdateEvent = _stateMgr.OnAdvReceived(std::move(adv));
     if (optUpdateEvent.has_value()) {
@@ -260,8 +298,13 @@ void Manager::OnAdvWatcherStateChanged(
         break;
 
     case Bluetooth::AdvertisementWatcher::State::Stopped:
-        emit ScannerAvailabilityChanged(false);
-        LOG(Warn, "Bluetooth AdvWatcher stopped. Error: '{}'.", optError.value_or("nullopt"));
+        if (_scannerWanted) {
+            emit ScannerAvailabilityChanged(false);
+            LOG(Warn, "Bluetooth AdvWatcher stopped. Error: '{}'.", optError.value_or("nullopt"));
+        }
+        else {
+            LOG(Info, "Bluetooth AdvWatcher stopped intentionally.");
+        }
         break;
 
     default:

--- a/Source/Core/AirPods.h
+++ b/Source/Core/AirPods.h
@@ -179,6 +179,7 @@ private:
     QString _deviceName;
     Model _boundModel{Model::Unknown};
     bool _deviceConnected{false};
+    bool _scannerWanted{false};
     bool _automaticEarDetection{false};
     uint64_t _requestedDeviceAddress{0};
     std::jthread _deviceLookupThread;
@@ -202,6 +203,7 @@ Q_SIGNALS:
     void Disconnected();
     void LidToggled(bool opened);
     void ScannerAvailabilityChanged(bool available);
+    void DeviceConnectionChanged(bool connected);
 };
 
 std::vector<Core::Bluetooth::Device> GetDevices();

--- a/Source/Core/Bluetooth_win.cpp
+++ b/Source/Core/Bluetooth_win.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include "../Logger.h"
+#include "AppleCP.h"
 #include "Debug.h"
 #include "OS/Windows.h"
 
@@ -341,19 +342,29 @@ void AdvertisementWatcher::OnReceived(const BluetoothLEAdvertisementReceivedEven
     for (uint32_t i = 0; i < manufacturerDataArray.Size(); ++i) {
         const auto &manufacturerData = manufacturerDataArray.GetAt(i);
         const auto companyId = manufacturerData.CompanyId();
-        const auto &data = manufacturerData.Data();
-
-        std::vector<uint8_t> stdData(data.data(), data.data() + data.Length());
 
 #if defined APD_DEBUG
         auto overrideAdv = DebugConfig::GetInstance().GetOverrideAdv();
         if (overrideAdv.has_value()) {
-            stdData = std::move(overrideAdv.value());
-            LOG(Trace, "Adv override: {}", Helper::ToString(stdData));
+            LOG(Trace, "Adv override: {}", Helper::ToString(overrideAdv.value()));
+            receivedData.manufacturerDataMap.insert_or_assign(
+                AppleCP::VendorId, std::move(overrideAdv.value()));
+            break;
         }
 #endif
 
-        receivedData.manufacturerDataMap.try_emplace(companyId, std::move(stdData));
+        if (companyId != AppleCP::VendorId) {
+            continue;
+        }
+
+        const auto &data = manufacturerData.Data();
+
+        receivedData.manufacturerDataMap.try_emplace(
+            companyId, data.data(), data.data() + data.Length());
+    }
+
+    if (receivedData.manufacturerDataMap.empty()) {
+        return;
     }
 
     std::lock_guard<std::mutex> lock{_mutex};

--- a/Source/Core/LowAudioLatency.cpp
+++ b/Source/Core/LowAudioLatency.cpp
@@ -18,84 +18,365 @@
 
 #include "LowAudioLatency.h"
 
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <vector>
+
 #include <QAudioDeviceInfo>
+#include <QIODevice>
 
 #include "../Logger.h"
 
 namespace Core::LowAudioLatency {
 
+namespace Details {
+
+std::vector<QAudioFormat> BuildSilenceFormatCandidates(
+    const QList<int> &sampleSizes, const QList<QAudioFormat::SampleType> &sampleTypes,
+    const QList<QAudioFormat::Endian> &byteOrders)
+{
+    auto orderedSampleSizes = sampleSizes;
+    std::sort(orderedSampleSizes.begin(), orderedSampleSizes.end());
+    orderedSampleSizes.erase(
+        std::unique(orderedSampleSizes.begin(), orderedSampleSizes.end()),
+        orderedSampleSizes.end());
+
+    constexpr std::array kSampleTypePreference{
+        QAudioFormat::SignedInt,
+        QAudioFormat::UnSignedInt,
+        QAudioFormat::Float,
+    };
+    constexpr std::array kByteOrderPreference{
+        QAudioFormat::LittleEndian,
+        QAudioFormat::BigEndian,
+    };
+
+    std::vector<QAudioFormat> candidates;
+    for (const auto sampleSize : orderedSampleSizes) {
+        for (const auto sampleType : kSampleTypePreference) {
+            if (!sampleTypes.contains(sampleType)) {
+                continue;
+            }
+            for (const auto byteOrder : kByteOrderPreference) {
+                if (!byteOrders.contains(byteOrder)) {
+                    continue;
+                }
+
+                QAudioFormat format;
+                format.setSampleRate(8000);
+                format.setChannelCount(1);
+                format.setSampleSize(sampleSize);
+                format.setCodec("audio/pcm");
+                format.setByteOrder(byteOrder);
+                format.setSampleType(sampleType);
+                candidates.push_back(format);
+            }
+        }
+    }
+    return candidates;
+}
+
+std::vector<uint8_t> CreateSilentFrame(const QAudioFormat &format)
+{
+    const auto bitsPerSample = std::max(1, format.sampleSize());
+    const auto bytesPerSample = std::max(1, (bitsPerSample + 7) / 8);
+    const auto channelCount = std::max(1, format.channelCount());
+    std::vector<uint8_t> frame(static_cast<size_t>(bytesPerSample * channelCount), 0);
+
+    if (format.sampleType() != QAudioFormat::UnSignedInt) {
+        return frame;
+    }
+
+    const auto midpointBit = bitsPerSample - 1;
+    const auto byteFromLeastSignificant = midpointBit / 8;
+    const auto midpointMask = static_cast<uint8_t>(1u << (midpointBit % 8));
+    const auto midpointByte = format.byteOrder() == QAudioFormat::LittleEndian
+                                  ? byteFromLeastSignificant
+                                  : bytesPerSample - byteFromLeastSignificant - 1;
+    for (auto channel = 0; channel < channelCount; ++channel) {
+        frame[static_cast<size_t>(channel * bytesPerSample + midpointByte)] = midpointMask;
+    }
+    return frame;
+}
+
+} // namespace Details
+
+namespace {
+
+QAudioFormat CreateSilenceFormat(const QAudioDeviceInfo &device)
+{
+    const auto candidates = Details::BuildSilenceFormatCandidates(
+        device.supportedSampleSizes(), device.supportedSampleTypes(), device.supportedByteOrders());
+    for (const auto &candidate : candidates) {
+        if (device.isFormatSupported(candidate)) {
+            return candidate;
+        }
+    }
+
+    QAudioFormat fallback;
+    fallback.setSampleRate(8000);
+    fallback.setChannelCount(1);
+    fallback.setSampleSize(16);
+    fallback.setCodec("audio/pcm");
+    fallback.setByteOrder(QAudioFormat::LittleEndian);
+    fallback.setSampleType(QAudioFormat::SignedInt);
+    return device.nearestFormat(fallback);
+}
+
+} // namespace
+
+class SilenceDevice final : public QIODevice
+{
+public:
+    explicit SilenceDevice(const QAudioFormat &format, QObject *parent = nullptr)
+        : QIODevice{parent}, _silentFrame{Details::CreateSilentFrame(format)}
+    {
+        _zeroFilled = std::all_of(
+            _silentFrame.cbegin(), _silentFrame.cend(), [](const auto byte) { return byte == 0; });
+    }
+
+    void Start()
+    {
+        open(QIODevice::ReadOnly);
+    }
+
+    void Stop()
+    {
+        close();
+    }
+
+    bool isSequential() const override
+    {
+        return true;
+    }
+
+    qint64 bytesAvailable() const override
+    {
+        return kBufferHint + QIODevice::bytesAvailable();
+    }
+
+protected:
+    qint64 readData(char *data, qint64 maxSize) override
+    {
+        if (maxSize <= 0) {
+            return 0;
+        }
+
+        if (_zeroFilled) {
+            std::memset(data, 0, static_cast<size_t>(maxSize));
+            return maxSize;
+        }
+
+        auto remaining = static_cast<size_t>(maxSize);
+        auto *output = reinterpret_cast<uint8_t *>(data);
+        while (remaining > 0) {
+            const auto chunk = std::min(remaining, _silentFrame.size() - _frameOffset);
+            std::memcpy(output, _silentFrame.data() + _frameOffset, chunk);
+            output += chunk;
+            remaining -= chunk;
+            _frameOffset = (_frameOffset + chunk) % _silentFrame.size();
+        }
+        return maxSize;
+    }
+
+    qint64 writeData(const char *, qint64) override
+    {
+        return -1;
+    }
+
+private:
+    constexpr static inline qint64 kBufferHint = 4096;
+    std::vector<uint8_t> _silentFrame;
+    size_t _frameOffset{0};
+    bool _zeroFilled{true};
+};
+
 Controller::Controller(QObject *parent) : QObject{parent}
 {
     connect(this, &Controller::ControlSafely, this, &Controller::Control);
+    connect(this, &Controller::SetDeviceConnectedSafely, this, &Controller::SetDeviceConnected);
 
+    _initTimer.setInterval(kRetryInterval);
     _initTimer.callOnTimeout([this] {
-        if (Initialize()) {
+        if (!_enabled || !_deviceConnected) {
             _initTimer.stop();
+            return;
         }
+        StartWhenReady();
     });
 
-    if (!Initialize()) {
-        // retry later
-        _initTimer.start(kRetryInterval);
-    }
+    _deviceCheckTimer.setInterval(kDeviceCheckInterval);
+    _deviceCheckTimer.callOnTimeout([this] { CheckOutputDevice(); });
+}
+
+Controller::~Controller()
+{
+    Stop();
 }
 
 bool Controller::Initialize()
 {
     // issue #20
     //
-    // Constructing `QMediaPlayer` when no audio output device is enabled will cause `play` to
-    // continually raise errors and is unrecoverable.
-    if (QAudioDeviceInfo::availableDevices(QAudio::AudioOutput).empty()) {
+    // Constructing audio output when no audio output device is enabled will cause repeated
+    // playback errors and is unrecoverable until the device list changes.
+    const auto devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+    if (devices.empty()) {
         LOG(Warn, "LowAudioLatency: Try to init, but no audio output device is enabled.");
         return false;
     }
 
-    _mediaPlayer = std::make_unique<QMediaPlayer>();
-    _mediaPlaylist = std::make_unique<QMediaPlaylist>();
+    const auto device = QAudioDeviceInfo::defaultOutputDevice();
+    const auto format = CreateSilenceFormat(device);
+    if (!format.isValid()) {
+        LOG(Warn, "LowAudioLatency: Default output device has no valid PCM format.");
+        return false;
+    }
 
-    connect(
-        _mediaPlayer.get(), qOverload<QMediaPlayer::Error>(&QMediaPlayer::error), this,
-        &Controller::OnError);
+    _silenceDevice = std::make_unique<SilenceDevice>(format);
+    _audioOutput = std::make_unique<QAudioOutput>(device, format, this);
+    _deviceName = device.deviceName();
 
-    _mediaPlaylist->addMedia(QUrl{"qrc:/Resource/Audio/Silence.mp3"});
-    _mediaPlaylist->setPlaybackMode(QMediaPlaylist::Loop);
-    _mediaPlayer->setPlaylist(_mediaPlaylist.get());
+    LOG(Info, "LowAudioLatency: Format: {} Hz, {} channel(s), {} bit, sample type {}.",
+        format.sampleRate(), format.channelCount(), format.sampleSize(), format.sampleType());
+
+    connect(_audioOutput.get(), &QAudioOutput::stateChanged, this, &Controller::OnStateChanged);
 
     _inited = true;
 
     LOG(Info, "LowAudioLatency: Init successful. _enabled: {}", _enabled);
 
-    if (_enabled) {
-        Control(true);
-    }
-
     return true;
+}
+
+bool Controller::StartWhenReady()
+{
+    if (!_inited && !Initialize()) {
+        _deviceCheckTimer.stop();
+        if (!_initTimer.isActive()) {
+            _initTimer.start();
+        }
+        return false;
+    }
+    _initTimer.stop();
+    Start();
+    _deviceCheckTimer.start();
+    return true;
+}
+
+void Controller::ResetAudio()
+{
+    Stop();
+    _audioOutput.reset();
+    _silenceDevice.reset();
+    _deviceName.clear();
+    _inited = false;
 }
 
 void Controller::Control(bool enable)
 {
     LOG(Info, "LowAudioLatency::Controller Control: {}, _inited: {}", enable, _inited);
 
-    if (_inited) {
-        if (enable) {
-            _mediaPlayer->play();
-        }
-        else {
-            _mediaPlayer->stop();
-        }
-    }
-
     _enabled = enable;
+
+    if (enable) {
+        if (!_deviceConnected) {
+            LOG(Info, "LowAudioLatency: Waiting for the bound device to connect.");
+            return;
+        }
+        StartWhenReady();
+    }
+    else {
+        _initTimer.stop();
+        _deviceCheckTimer.stop();
+        ResetAudio();
+    }
 }
 
-void Controller::OnError(QMediaPlayer::Error error)
+void Controller::SetDeviceConnected(bool connected)
 {
-    LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", error);
+    if (_deviceConnected == connected) {
+        return;
+    }
 
-    _mediaPlayer->stop();
-    _inited = false;
-    _initTimer.start(kRetryInterval);
+    _deviceConnected = connected;
+    if (!_enabled) {
+        return;
+    }
+
+    if (!connected) {
+        LOG(Info, "LowAudioLatency: Bound device disconnected; releasing the audio stream.");
+        _initTimer.stop();
+        _deviceCheckTimer.stop();
+        ResetAudio();
+        return;
+    }
+
+    LOG(Info, "LowAudioLatency: Bound device connected; starting the audio stream.");
+    StartWhenReady();
+}
+
+void Controller::Start()
+{
+    if (!_inited || !_enabled || !_deviceConnected || !_audioOutput || !_silenceDevice) {
+        return;
+    }
+
+    if (_audioOutput->state() == QAudio::ActiveState || _audioOutput->state() == QAudio::IdleState)
+    {
+        return;
+    }
+
+    _silenceDevice->Start();
+    _audioOutput->start(_silenceDevice.get());
+}
+
+void Controller::Stop()
+{
+    if (_audioOutput) {
+        _audioOutput->stop();
+    }
+    if (_silenceDevice) {
+        _silenceDevice->Stop();
+    }
+}
+
+void Controller::CheckOutputDevice()
+{
+    if (!_enabled || !_deviceConnected) {
+        return;
+    }
+
+    const auto device = QAudioDeviceInfo::defaultOutputDevice();
+    if (!device.isNull() && device.deviceName() == _deviceName) {
+        return;
+    }
+
+    LOG(Info, "LowAudioLatency: Default output device changed; recreating the silence stream.");
+    ResetAudio();
+    StartWhenReady();
+}
+
+void Controller::OnStateChanged(QAudio::State state)
+{
+    if (!_enabled) {
+        return;
+    }
+
+    if (state == QAudio::StoppedState && _audioOutput && _audioOutput->error() != QAudio::NoError) {
+        LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", _audioOutput->error());
+        // Do not destroy QAudioOutput while it is emitting stateChanged.
+        const auto *failedOutput = _audioOutput.get();
+        QTimer::singleShot(0, this, [this, failedOutput] {
+            if (!_enabled || !_deviceConnected || _audioOutput.get() != failedOutput) {
+                return;
+            }
+            _deviceCheckTimer.stop();
+            ResetAudio();
+            _initTimer.start();
+        });
+    }
 }
 
 } // namespace Core::LowAudioLatency

--- a/Source/Core/LowAudioLatency.h
+++ b/Source/Core/LowAudioLatency.h
@@ -18,16 +18,31 @@
 
 #pragma once
 
-#include <memory>
 #include <chrono>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
+#include <QAudioFormat>
+#include <QAudioOutput>
+#include <QList>
+#include <QString>
 #include <QTimer>
-#include <QMediaPlayer>
-#include <QMediaPlaylist>
 
 using namespace std::chrono_literals;
 
 namespace Core::LowAudioLatency {
+
+namespace Details {
+
+std::vector<QAudioFormat> BuildSilenceFormatCandidates(
+    const QList<int> &sampleSizes, const QList<QAudioFormat::SampleType> &sampleTypes,
+    const QList<QAudioFormat::Endian> &byteOrders);
+std::vector<uint8_t> CreateSilentFrame(const QAudioFormat &format);
+
+} // namespace Details
+
+class SilenceDevice;
 
 class Controller : public QObject
 {
@@ -35,22 +50,32 @@ class Controller : public QObject
 
 public:
     Controller(QObject *parent = nullptr);
+    ~Controller();
 
 Q_SIGNALS:
     void ControlSafely(bool enable);
+    void SetDeviceConnectedSafely(bool connected);
 
 private:
     constexpr static inline auto kRetryInterval = 30s;
-
-    std::unique_ptr<QMediaPlayer> _mediaPlayer;
-    std::unique_ptr<QMediaPlaylist> _mediaPlaylist;
+    constexpr static inline auto kDeviceCheckInterval = 5s;
+    std::unique_ptr<QAudioOutput> _audioOutput;
+    std::unique_ptr<SilenceDevice> _silenceDevice;
     QTimer _initTimer;
-    bool _inited{false}, _enabled{false};
+    QTimer _deviceCheckTimer;
+    QString _deviceName;
+    bool _inited{false}, _enabled{false}, _deviceConnected{false};
 
     bool Initialize();
+    bool StartWhenReady();
+    void ResetAudio();
     void Control(bool enable);
+    void SetDeviceConnected(bool connected);
 
-    void OnError(QMediaPlayer::Error error);
+    void Start();
+    void Stop();
+    void CheckOutputDevice();
+    void OnStateChanged(QAudio::State state);
 };
 
 } // namespace Core::LowAudioLatency

--- a/Source/Core/Settings.h
+++ b/Source/Core/Settings.h
@@ -63,7 +63,7 @@ void SetRepository(std::unique_ptr<Repository> repository);
     callback(bool, auto_run, {false}, Impl::OnApply(&OnApply_auto_run))                            \
     callback(bool, low_audio_latency, {false},                                                     \
         Impl::OnApply(&OnApply_low_audio_latency),                                                 \
-        Impl::Desc{QObject::tr("It fixes short audio playback problems, but may increase battery consumption.")}) \
+        Impl::Desc{QObject::tr("Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.")}) \
     callback(bool, automatic_ear_detection, {true},                                                \
         Impl::OnApply(&OnApply_automatic_ear_detection),                                           \
         Impl::Desc{QObject::tr("It automatically pauses or resumes media when your AirPods are taken out or put in your ears.")}) \

--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -400,7 +400,12 @@ void MainWindow::SetAnimation(std::optional<Core::AirPods::Model> model)
 
         _mediaPlayer->setMedia(QUrl{presentation.resource});
 
-        PlayAnimation();
+        if (_isVisible) {
+            PlayAnimation();
+        }
+        else {
+            StopAnimation();
+        }
     }
 
     _cacheModel = model;

--- a/Source/Gui/SettingsWindow.cpp
+++ b/Source/Gui/SettingsWindow.cpp
@@ -206,6 +206,14 @@ int SettingsWindow::GetTabCount() const
     return _ui.tabWidget->count();
 }
 
+void SettingsWindow::SetLowAudioLatencyChecked(bool checked)
+{
+    const auto oldTrigger = _trigger;
+    _trigger = false;
+    _ui.cbLowAudioLatency->setChecked(checked);
+    _trigger = oldTrigger;
+}
+
 int SettingsWindow::GetTabCurrentIndex() const
 {
     return _ui.tabWidget->currentIndex();

--- a/Source/Gui/SettingsWindow.h
+++ b/Source/Gui/SettingsWindow.h
@@ -40,6 +40,7 @@ class SettingsWindow : public QDialog
 
 public:
     explicit SettingsWindow(std::function<int()> getCurrentLocaleIndex, QWidget *parent = nullptr);
+    void SetLowAudioLatencyChecked(bool checked);
 
     int GetTabCount() const;
     int GetTabCurrentIndex() const;

--- a/Source/Gui/TaskbarStatus.cpp
+++ b/Source/Gui/TaskbarStatus.cpp
@@ -222,7 +222,7 @@ bool TaskbarStatus::Enable()
     setAttribute(Qt::WA_TranslucentBackground);
     UpdatePos(info, true);
     _isFirstTimeout = true;
-    _updateTimer.start(kUpdateInterval);
+    _updateTimer.start(kInitialUpdateInterval);
     show();
     return true;
 }
@@ -425,6 +425,7 @@ void TaskbarStatus::OnUpdateTimer()
     // first update may cause some shifting, I guess it's `setParent` causing some weird Qt bugs.
     if (_isFirstTimeout) {
         _isFirstTimeout = false;
+        _updateTimer.setInterval(kIdleUpdateInterval);
     }
 
     if (taskbarResized) {

--- a/Source/Gui/TaskbarStatus.h
+++ b/Source/Gui/TaskbarStatus.h
@@ -135,7 +135,8 @@ private:
     constexpr static inline auto kFixedWidth{60};  // for horizontal taskbar
     constexpr static inline auto kFixedHeight{40}; // for vertical taskbar
 
-    constexpr static inline auto kUpdateInterval{100ms};
+    constexpr static inline auto kInitialUpdateInterval{100ms};
+    constexpr static inline auto kIdleUpdateInterval{2s};
 
     Ui::TaskbarStatus _ui;
     Helper::Sides<MiniIcon *> _icon = {new MiniIcon{this}, new MiniIcon{this}};

--- a/Source/Gui/TrayIcon.cpp
+++ b/Source/Gui/TrayIcon.cpp
@@ -30,6 +30,9 @@ TrayIcon::TrayIcon(std::function<int()> getCurrentLocaleIndex)
     : _settingsWindow{std::move(getCurrentLocaleIndex)}
 {
     connect(_actionNewVersion, &QAction::triggered, this, &TrayIcon::OnNewVersionClicked);
+    connect(_actionLowAudioLatency, &QAction::triggered, this, [](bool enabled) {
+        Core::Settings::ModifiableAccess()->low_audio_latency = enabled;
+    });
     connect(_actionSettings, &QAction::triggered, this, &TrayIcon::OnSettingsClicked);
     connect(_actionAbout, &QAction::triggered, this, &TrayIcon::OnAboutClicked);
     connect(_actionQuit, &QAction::triggered, qApp, &QApplication::quit, Qt::QueuedConnection);
@@ -38,11 +41,15 @@ TrayIcon::TrayIcon(std::function<int()> getCurrentLocaleIndex)
 
     connect(
         this, &TrayIcon::OnTrayIconBatteryChangedSafely, this, &TrayIcon::OnTrayIconBatteryChanged);
+    connect(
+        this, &TrayIcon::OnLowAudioLatencyChangedSafely, this, &TrayIcon::OnLowAudioLatencyChanged);
 
     _actionNewVersion->setVisible(false);
+    _actionLowAudioLatency->setCheckable(true);
 
     _menu->addAction(_actionNewVersion);
     _menu->addSeparator();
+    _menu->addAction(_actionLowAudioLatency);
     _menu->addAction(_actionSettings);
     _menu->addSeparator();
     _menu->addAction(_actionAbout);
@@ -205,7 +212,6 @@ void TrayIcon::Repaint()
     } while (false);
 
     static const QColor kNewVersionAvailableDot = Qt::yellow;
-
     auto optIcon = GenerateIcon(
         64, iconText,
         _updateReleaseInfo.has_value() ? std::optional<QColor>{kNewVersionAvailableDot}
@@ -361,6 +367,12 @@ void TrayIcon::OnTrayIconBatteryChanged(Core::Settings::TrayIconBatteryBehavior 
 {
     _trayIconBatteryBehavior = value;
     Repaint();
+}
+
+void TrayIcon::OnLowAudioLatencyChanged(bool enabled)
+{
+    _actionLowAudioLatency->setChecked(enabled);
+    _settingsWindow.SetLowAudioLatencyChecked(enabled);
 }
 
 } // namespace Gui

--- a/Source/Gui/TrayIcon.cpp
+++ b/Source/Gui/TrayIcon.cpp
@@ -212,12 +212,22 @@ void TrayIcon::Repaint()
     } while (false);
 
     static const QColor kNewVersionAvailableDot = Qt::yellow;
+    const IconRenderState nextIconRenderState{
+        .text = iconText,
+        .showUpdateDot = _updateReleaseInfo.has_value(),
+    };
+
+    if (_lastIconRenderState == nextIconRenderState) {
+        return;
+    }
+
     auto optIcon = GenerateIcon(
-        64, iconText,
-        _updateReleaseInfo.has_value() ? std::optional<QColor>{kNewVersionAvailableDot}
-                                       : std::nullopt);
+        64, nextIconRenderState.text,
+        nextIconRenderState.showUpdateDot ? std::optional<QColor>{kNewVersionAvailableDot}
+                                          : std::nullopt);
     if (optIcon.has_value()) {
         _tray->setIcon(QIcon{QPixmap::fromImage(optIcon.value())});
+        _lastIconRenderState = nextIconRenderState;
     }
 }
 

--- a/Source/Gui/TrayIcon.h
+++ b/Source/Gui/TrayIcon.h
@@ -53,6 +53,7 @@ public:
 
 Q_SIGNALS:
     void OnTrayIconBatteryChangedSafely(Core::Settings::TrayIconBatteryBehavior value);
+    void OnLowAudioLatencyChangedSafely(bool enabled);
     void ShowMainWindowRequested();
     void UserUpdateRequested(const Core::Update::ReleaseInfo &releaseInfo);
     void ToolTipChanged(const QString &text);
@@ -61,6 +62,7 @@ private:
     QSystemTrayIcon *_tray = new QSystemTrayIcon{this};
     QMenu *_menu = new QMenu{this};
     QAction *_actionNewVersion = new QAction{tr("New version available!"), this};
+    QAction *_actionLowAudioLatency = new QAction{tr("Low audio latency (may cause hiss)"), this};
     QAction *_actionSettings = new QAction{tr("Settings"), this};
     QAction *_actionAbout = new QAction{tr("About"), this};
     QAction *_actionQuit = new QAction{tr("Quit"), this};
@@ -82,6 +84,7 @@ private:
     void OnAboutClicked();
     void OnIconClicked(QSystemTrayIcon::ActivationReason reason);
     void OnTrayIconBatteryChanged(Core::Settings::TrayIconBatteryBehavior value);
+    void OnLowAudioLatencyChanged(bool enabled);
 
 protected:
     SettingsWindow _settingsWindow;

--- a/Source/Gui/TrayIcon.h
+++ b/Source/Gui/TrayIcon.h
@@ -59,6 +59,13 @@ Q_SIGNALS:
     void ToolTipChanged(const QString &text);
 
 private:
+    struct IconRenderState {
+        std::optional<QString> text;
+        bool showUpdateDot{false};
+
+        bool operator==(const IconRenderState &rhs) const = default;
+    };
+
     QSystemTrayIcon *_tray = new QSystemTrayIcon{this};
     QMenu *_menu = new QMenu{this};
     QAction *_actionNewVersion = new QAction{tr("New version available!"), this};
@@ -72,6 +79,7 @@ private:
     std::optional<Core::AirPods::State> _airPodsState;
     std::optional<QString> _displayName;
     std::optional<Core::Update::ReleaseInfo> _updateReleaseInfo;
+    std::optional<IconRenderState> _lastIconRenderState;
 
     void ShowMainWindow();
     void Repaint();

--- a/Source/Resource/Resource.qrc
+++ b/Source/Resource/Resource.qrc
@@ -11,6 +11,5 @@
         <file>Video/AirPods_Pro_3.avi</file>
         <file>Video/AirPods_Max.avi</file>
         <file>Video/Beats_Fit_Pro.avi</file>
-        <file>Audio/Silence.mp3</file>
     </qresource>
 </RCC>

--- a/Source/Resource/Translation/apd_de_DE.ts
+++ b/Source/Resource/Translation/apd_de_DE.ts
@@ -149,6 +149,10 @@ Neueste Version: %2%3</translation>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Niedrige Audiolatenz (kann Rauschen verursachen)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Behebt Probleme bei der Wiedergabe kurzer Audioclips, kann jedoch den Akkuverbrauch erhöhen.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Hält Medien automatisch an oder setzt die Wiedergabe fort, wenn du deine AirPods aus den Ohren nimmst oder einsetzt.</translation>
     </message>
@@ -203,6 +203,10 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     <message>
         <source>Waiting for Binding</source>
         <translation>Warte auf Verbindung</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Hält das Audiogerät aktiv, während deine AirPods verbunden sind, damit kurze Töne sofort wiedergegeben werden. Dies kann hörbares Rauschen verursachen und den Akkuverbrauch erhöhen.</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_fr_FR.ts
+++ b/Source/Resource/Translation/apd_fr_FR.ts
@@ -149,6 +149,10 @@ Dernière version : %2%3</translation>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Faible latence audio (peut provoquer un souffle)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Il résout les problèmes de lecture audio de courte durée, mais peut augmenter la consommation de la batterie.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Il met automatiquement en pause ou reprend le média lorsque vous retirez ou remettez vos AirPods dans vos oreilles.</translation>
     </message>
@@ -203,6 +203,10 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     <message>
         <source>Waiting for Binding</source>
         <translation>En attente de connexion</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Maintient le périphérique audio actif pendant que vos AirPods sont connectés afin que les sons courts démarrent immédiatement. Cela peut produire un souffle audible et augmenter la consommation de la batterie.</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_ja_JP.ts
+++ b/Source/Resource/Translation/apd_ja_JP.ts
@@ -149,6 +149,10 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>低音声レイテンシー（ノイズが発生する場合があります）</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>短い音声が正常に再生されない問題を改善しますが、バッテリー消費量が増える場合があります。</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>AirPodsを外すと自動的に一時停止し、着けると再生を再開します。</translation>
     </message>
@@ -203,6 +203,10 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>接続待機中</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>AirPodsが接続されている間、オーディオデバイスを起動状態に保ち、短い音声をすぐに再生できるようにします。聞こえる程度のノイズが発生したり、バッテリー消費が増えたりする場合があります。</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_ko_KR.ts
+++ b/Source/Resource/Translation/apd_ko_KR.ts
@@ -149,6 +149,10 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>낮은 오디오 지연 시간(잡음이 발생할 수 있음)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>짧은 오디오 재생 문제를 해결하지만 배터리 소모를 증가시킬 수 있습니다.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>AirPods을 빼거나 귀에 넣으면 자동으로 미디어를 일시 중지하거나 다시 시작합니다.</translation>
     </message>
@@ -203,6 +203,10 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>연결 대기 중</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>AirPods이 연결되어 있는 동안 오디오 장치를 활성 상태로 유지하여 짧은 소리가 즉시 재생되도록 합니다. 잡음이 들리거나 배터리 사용량이 증가할 수 있습니다.</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_ru_RU.ts
+++ b/Source/Resource/Translation/apd_ru_RU.ts
@@ -149,6 +149,10 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>Выйти</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Низкая задержка звука (может вызвать шипение)</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Это устраняет проблемы с воспроизведением коротких аудиофрагментов, но может увеличить расход заряда наушников.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Автоматическая приостановка или возобновление воспроизведения мультимедиа, когда вы снимаете или надеваете AirPods.</translation>
     </message>
@@ -203,6 +203,10 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>Ожидание привязки</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Поддерживает аудиоустройство активным, пока AirPods подключены, чтобы короткие звуки воспроизводились сразу. Это может вызвать слышимое шипение и увеличить расход заряда.</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_zh_CN.ts
+++ b/Source/Resource/Translation/apd_zh_CN.ts
@@ -149,6 +149,10 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>低音频延迟（可能产生嘶嘶声）</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>修复短音频的播放问题，但可能会增加电池消耗。</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>当您取下或戴上 AirPods 时，自动暂停或恢复媒体播放。</translation>
     </message>
@@ -203,6 +203,10 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>等待绑定</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>在 AirPods 连接期间保持音频设备唤醒，使短促提示音能够立即播放。这可能会产生可听见的嘶嘶声，并增加电池消耗。</translation>
     </message>
 </context>
 <context>

--- a/Source/Resource/Translation/apd_zh_TW.ts
+++ b/Source/Resource/Translation/apd_zh_TW.ts
@@ -149,6 +149,10 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>結束</translation>
     </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>低音訊延遲（可能產生嘶嘶聲）</translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -185,10 +189,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>可修正短音訊無法正常播放的問題，但可能會增加電池耗電量。</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>當您取下或戴上 AirPods 時，自動暫停或繼續播放媒體。</translation>
     </message>
@@ -203,6 +203,10 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>等待連線</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>在 AirPods 連線期間保持音訊裝置喚醒，讓短促提示音能立即播放。這可能會產生可聽見的嘶嘶聲，並增加電池消耗。</translation>
     </message>
 </context>
 <context>

--- a/Source/Utils.h
+++ b/Source/Utils.h
@@ -122,7 +122,7 @@ inline QDir GetWorkspace()
 
     QDir result{std::move(location)};
     if (!result.exists()) {
-        result.mkdir(".");
+        result.mkpath(".");
     }
     return result;
 }

--- a/Tests/AirPodsDomainTests.cpp
+++ b/Tests/AirPodsDomainTests.cpp
@@ -8,6 +8,7 @@
 
 #include <Config.h>
 #include "Source/Core/AirPods.h"
+#include "Source/Core/LowAudioLatency.h"
 #include "Source/Core/Settings.h"
 #include "Source/Core/SettingsRepository.h"
 #include "Source/Core/Update.h"
@@ -97,6 +98,8 @@ private Q_SLOTS:
     void MergesAdvertisementsFromBothSides();
     void RejectsAdvertisementsFromDifferentModels();
     void AcceptsKnownModelAfterUnknownAdvertisement();
+    void BuildsLowBandwidthSilenceFormats();
+    void CreatesCorrectPcmSilenceFrames();
     void LoadsSettingsThroughRepository();
     void RejectsNullSettingsRepository();
     void ParsesUpdateVersions();
@@ -124,6 +127,63 @@ void AirPodsDomainTests::RejectsMalformedPackets()
     packet = MakePacket(0x2014, Side::Left, 8, 7, 5);
     packet[1] = 24;
     QVERIFY(!Core::AppleCP::AirPods::IsValid(packet));
+}
+
+void AirPodsDomainTests::BuildsLowBandwidthSilenceFormats()
+{
+    const auto candidates = Core::LowAudioLatency::Details::BuildSilenceFormatCandidates(
+        {16, 8, 16}, {QAudioFormat::Float, QAudioFormat::UnSignedInt, QAudioFormat::SignedInt},
+        {QAudioFormat::BigEndian, QAudioFormat::LittleEndian});
+
+    QCOMPARE(candidates.size(), size_t{12});
+    for (const auto &candidate : candidates) {
+        QCOMPARE(candidate.sampleRate(), 8000);
+        QCOMPARE(candidate.channelCount(), 1);
+        QCOMPARE(candidate.codec(), QString{"audio/pcm"});
+    }
+
+    QCOMPARE(candidates.front().sampleSize(), 8);
+    QCOMPARE(candidates.front().sampleType(), QAudioFormat::SignedInt);
+    QCOMPARE(candidates.front().byteOrder(), QAudioFormat::LittleEndian);
+}
+
+void AirPodsDomainTests::CreatesCorrectPcmSilenceFrames()
+{
+    const auto makeFormat = [](int sampleSize, int channelCount,
+                               QAudioFormat::SampleType sampleType,
+                               QAudioFormat::Endian byteOrder) {
+        QAudioFormat format;
+        format.setSampleSize(sampleSize);
+        format.setChannelCount(channelCount);
+        format.setSampleType(sampleType);
+        format.setByteOrder(byteOrder);
+        return format;
+    };
+
+    const std::vector<uint8_t> signedSilence{0, 0, 0, 0};
+    QVERIFY(
+        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
+            16, 2, QAudioFormat::SignedInt, QAudioFormat::LittleEndian)) == signedSilence);
+
+    const std::vector<uint8_t> floatSilence{0, 0, 0, 0};
+    QVERIFY(
+        Core::LowAudioLatency::Details::CreateSilentFrame(
+            makeFormat(32, 1, QAudioFormat::Float, QAudioFormat::LittleEndian)) == floatSilence);
+
+    const std::vector<uint8_t> unsignedLittleEndian{0, 0x80, 0, 0x80};
+    QVERIFY(
+        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
+            16, 2, QAudioFormat::UnSignedInt, QAudioFormat::LittleEndian)) == unsignedLittleEndian);
+
+    const std::vector<uint8_t> unsignedBigEndian{0x80, 0};
+    QVERIFY(
+        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
+            16, 1, QAudioFormat::UnSignedInt, QAudioFormat::BigEndian)) == unsignedBigEndian);
+
+    const std::vector<uint8_t> unsignedTwentyBit{0, 0, 0x08};
+    QVERIFY(
+        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
+            20, 1, QAudioFormat::UnSignedInt, QAudioFormat::LittleEndian)) == unsignedTwentyBit);
 }
 
 void AirPodsDomainTests::ParsesAdvertisementState()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "airpods-desktop",
-  "version-string": "0.5.0",
+  "version-string": "0.5.1",
   "dependencies": [
     {
       "name": "cpr",


### PR DESCRIPTION
## Summary

Most of this work is @aizuon's, from #199. Five of the six commits carry a
`Co-authored-by:` trailer for that reason - `AirPods.cpp`, `Bluetooth_win.cpp`,
`TaskbarStatus.cpp`, `TrayIcon.cpp` and `Resource.qrc` are unchanged from that PR, and the
seven translation catalogs differ by two lines. What this branch adds on top is the
low-latency audio rework (`LowAudioLatency.cpp`, +115/-48 against #199) with regression
coverage, and the `QDir::mkpath` fix, which is the one commit that is not co-authored.

It refines that work and keeps the behavior scoped to the bound AirPods device.

- Stop BLE scanning while the bound device is disconnected, filter unrelated advertisements before parsing, pause hidden animations, reduce steady-state taskbar polling, and cache unchanged tray icon renders.
- Replace the always-running packaged silence track with a connection-aware raw silence stream. Enumerate all supported 8 kHz mono PCM formats before falling back to Qt negotiation, and serialize audio recovery so disconnect/error paths cannot start duplicate timers.
- Synchronize the tray low-latency toggle with settings, keep first-use opt-in behavior, and complete bundled translations for new warnings.
- Fix fresh-profile startup by recursively creating the application data directory with QDir::mkpath.
- Add regression coverage for PCM format candidates and generated signed, unsigned, and floating-point silence frames.

## Validation

- Win32 RelWithDebInfo build with Qt 5.15.2 / MSVC.
- ctest --test-dir Build -C RelWithDebInfo --output-on-failure (1/1 passed).
- Real Windows + AirPods validation: normal playback succeeded; connected low-latency initialization used 8000 Hz mono 8-bit; disconnect released the stream and stopped BLE scanning; reconnect initialized each component once; no audio errors or retry loops observed.
- Resource sampling: disconnected idle stayed at 0% CPU with no memory/log growth over 20 seconds; connected non-trace idle remained responsive with stable memory.

This branch is based on the current upstream main and intentionally excludes the unrelated CMake/vcpkg changes from #199.
