### PR TITLE
docs: credit @aizuon for the idle performance and low-latency audio work

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -56,3 +56,6 @@
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### 贡献者
+* [@aizuon](https://github.com/aizuon) — 闲置 CPU 与低延迟音频重构，提交于 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，经由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合并

--- a/README-TW.md
+++ b/README-TW.md
@@ -56,3 +56,6 @@
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### 貢獻者
+* [@aizuon](https://github.com/aizuon) — 閒置 CPU 與低延遲音訊重構，提交於 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，經由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合併

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ See the [Build Instructions](/Docs/Build.md).
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### Contributors
+* [@aizuon](https://github.com/aizuon) — idle CPU and low-latency audio rework, contributed in [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) and merged through [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210)


### PR DESCRIPTION
## Summary

Adds a `Contributors` entry to the three READMEs crediting @aizuon for the idle-CPU and
low-latency audio work.

That work reached `main` through #210, which I opened. Its commits carry no
`Co-authored-by:` trailer, so GitHub attributes none of it to the person who actually wrote
it — @aizuon has zero commits in `main` under his own name, even though most of what #210
merged is his.

## Why the READMEs rather than the commits

Comparing the two branches file by file rather than by description:

| | |
|---|---|
| `Source/Core/AirPods.cpp`, `Source/Core/Bluetooth_win.cpp`, `Source/Gui/TaskbarStatus.cpp`, `Source/Gui/TrayIcon.cpp`, `Source/Resource/Resource.qrc` | byte-identical between #199 and #210 |
| the seven translation catalogs | two lines different each |
| `Source/Gui/MainWindow.cpp` | three lines different |
| `Source/Core/LowAudioLatency.cpp` | +115/-48 against #199 — this is where #210 diverges |
| `Source/Utils.h` (`QDir::mkpath`) | only in #210; #199 never touched that file |

The right fix would have been a `Co-authored-by:` trailer on the five commits that carry his
work. I prepared exactly that, but #210 had already been merged (`c3a5a3f`) about ten minutes
earlier, so the trailer never reached `main`. Adding it now would mean rewriting published
history on `main`, which is not worth doing to anyone who has already fetched it.

A README entry is the non-destructive way to record it. If you would rather handle this in the
v0.5.1 release notes instead, or word it differently, say so and I will drop or adjust this.

## Changes

Three lines added per file, nothing else touched:

- `README.md` — `### Contributors`
- `README-CN.md` — `### 贡献者`
- `README-TW.md` — `### 貢獻者`

cc @aizuon
