### PR TITLE
docs: credit the PR #199 performance work

### DIFF
--- a/Docs/Performance.md
+++ b/Docs/Performance.md
@@ -1,0 +1,53 @@
+# Performance Notes
+
+AirPodsDesktop is intended to remain active in the notification area, so background CPU usage is
+treated as a product constraint rather than only a benchmark metric. Pull request
+[#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) supplied the original measurements and
+implementation work; pull request [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210)
+integrated and extended that work for version 0.5.1.
+
+## Recorded idle baseline
+
+The author of #199 measured process CPU time over a 60-second idle window on Windows. These values
+are retained as a historical regression baseline:
+
+| Build | Process CPU time | Approximate total CPU usage |
+| --- | ---: | ---: |
+| Installed 0.4.1 | 8.73 seconds | 0.91% |
+| Rebuilt #199 branch | 0.42 seconds | 0.04% |
+
+The measurements came from one machine and were not collected by an automated benchmark. Hardware,
+logical processor count, Bluetooth state, audio devices, taskbar configuration, and enabled settings
+can all affect the result. Use the numbers to detect large regressions, not as a universal performance
+guarantee.
+
+## What reduced background work
+
+The 0.5.1 implementation incorporates the main lifecycle changes explored in #199:
+
+- BLE scanning follows the bound device's connection state and ignores unrelated manufacturer data
+  before parsing it.
+- Hidden tray-popup animations stop decoding frames.
+- Low-latency audio uses a generated silent PCM stream and only keeps the output active while the
+  bound device is connected.
+- Tray icons are reused until their rendered battery state changes.
+- Taskbar geometry polling slows down after its initial positioning pass.
+
+## Reproducing an idle measurement
+
+1. Build the Win32 `RelWithDebInfo` configuration described in [Build.md](Build.md).
+2. Start AirPodsDesktop with the same device binding, Bluetooth state, taskbar settings, and
+   low-latency audio setting for every candidate build.
+3. Allow startup work and device discovery to settle before recording a sample.
+4. Record the process CPU-time increase across a fixed 60-second window. Repeat the sample several
+   times and report the median together with the machine's logical processor count.
+5. Note whether the AirPods were connected and whether the main window or tray popup was visible.
+
+When converting process CPU time to average total CPU usage, use:
+
+```text
+total CPU usage (%) = process CPU seconds / (elapsed seconds * logical processors) * 100
+```
+
+Keep the raw process CPU-time value in reports so results can still be compared across machines with
+different processor counts.

--- a/README-CN.md
+++ b/README-CN.md
@@ -56,3 +56,6 @@
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### 贡献者
+* [@aizuon](https://github.com/aizuon) — 闲置 CPU 与低延迟音频重构，提交于 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，经由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合并

--- a/README-CN.md
+++ b/README-CN.md
@@ -58,4 +58,4 @@
 * [MagicPods](https://magicpods.app/)
 
 ### 贡献者
-* [@aizuon](https://github.com/aizuon) — 闲置 CPU 与低延迟音频重构，提交于 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，经由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合并
+* [@aizuon](https://github.com/aizuon) — 闲置 CPU 与低延迟音频重构，提交于 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，经由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合并；另见[性能说明](/Docs/Performance.md)

--- a/README-TW.md
+++ b/README-TW.md
@@ -56,3 +56,6 @@
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### 貢獻者
+* [@aizuon](https://github.com/aizuon) — 閒置 CPU 與低延遲音訊重構，提交於 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，經由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合併

--- a/README-TW.md
+++ b/README-TW.md
@@ -58,4 +58,4 @@
 * [MagicPods](https://magicpods.app/)
 
 ### 貢獻者
-* [@aizuon](https://github.com/aizuon) — 閒置 CPU 與低延遲音訊重構，提交於 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，經由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合併
+* [@aizuon](https://github.com/aizuon) — 閒置 CPU 與低延遲音訊重構，提交於 [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199)，經由 [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210) 合併；另見[效能說明](/Docs/Performance.md)

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ See the [Build Instructions](/Docs/Build.md).
 * [MagicPods](https://magicpods.app/)
 
 ### Contributors
-* [@aizuon](https://github.com/aizuon) — idle CPU and low-latency audio rework, contributed in [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) and merged through [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210)
+* [@aizuon](https://github.com/aizuon) — idle CPU and low-latency audio rework, contributed in [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) and merged through [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210); see the [performance notes](/Docs/Performance.md)

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ See the [Build Instructions](/Docs/Build.md).
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
+
+### Contributors
+* [@aizuon](https://github.com/aizuon) — idle CPU and low-latency audio rework, contributed in [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) and merged through [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210)


### PR DESCRIPTION
## Summary

- credit @aizuon for the idle CPU and low-latency audio work proposed in #199 and integrated through #210
- preserve the original 60-second CPU measurements as a historical regression baseline
- document a repeatable idle-performance measurement procedure and link it from all three READMEs

## Motivation

PR #210 integrated and extended the performance work from #199, but its rewritten commits did not retain the original author's attribution. This follow-up records that contribution in the project documentation and includes Dorukhan Tokay as a co-author of the performance-baseline commit using the email already associated with the original #199 commits.

## Validation

- git diff --check upstream/main...HEAD
- documentation-only change; Qt build and runtime tests not required

Closes #199.