### PR TITLE
feat: consolidate community translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(APD_QRC_FILE "Source/Resource/Resource.qrc")
 #           https://stackoverflow.com/a/60848939
 #
 
-set(APD_TRANSLATION_LOCALES bg_BG de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU tr_TR zh_CN zh_TW)
+set(APD_TRANSLATION_LOCALES bg_BG de_DE fr_FR it_IT ja_JP ko_KR pt_BR pt_PT ru_RU tr_TR uk_UA zh_CN zh_TW)
 set(APD_TS_DIR "${CMAKE_SOURCE_DIR}/Source/Resource/Translation/")
 set(APD_QM_DIR "${APD_BINARY_OUT_DIR}/translations/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(APD_QRC_FILE "Source/Resource/Resource.qrc")
 #           https://stackoverflow.com/a/60848939
 #
 
-set(APD_TRANSLATION_LOCALES bg_BG de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU zh_CN zh_TW)
+set(APD_TRANSLATION_LOCALES bg_BG de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU tr_TR zh_CN zh_TW)
 set(APD_TS_DIR "${CMAKE_SOURCE_DIR}/Source/Resource/Translation/")
 set(APD_QM_DIR "${APD_BINARY_OUT_DIR}/translations/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(APD_QRC_FILE "Source/Resource/Resource.qrc")
 #           https://stackoverflow.com/a/60848939
 #
 
-set(APD_TRANSLATION_LOCALES de_DE fr_FR ja_JP ko_KR pt_BR ru_RU zh_CN zh_TW)
+set(APD_TRANSLATION_LOCALES de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU zh_CN zh_TW)
 set(APD_TS_DIR "${CMAKE_SOURCE_DIR}/Source/Resource/Translation/")
 set(APD_QM_DIR "${APD_BINARY_OUT_DIR}/translations/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ set(APD_QRC_FILE "Source/Resource/Resource.qrc")
 #           https://stackoverflow.com/a/60848939
 #
 
-set(APD_TRANSLATION_LOCALES de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU zh_CN zh_TW)
+set(APD_TRANSLATION_LOCALES bg_BG de_DE fr_FR ja_JP ko_KR pt_BR pt_PT ru_RU zh_CN zh_TW)
 set(APD_TS_DIR "${CMAKE_SOURCE_DIR}/Source/Resource/Translation/")
 set(APD_QM_DIR "${APD_BINARY_OUT_DIR}/translations/")
 

--- a/Source/Resource/Translation/apd_bg_BG.ts
+++ b/Source/Resource/Translation/apd_bg_BG.ts
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bg_BG">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>Форматът на настройките е малко променен и трябва да бъде преконфигуриран.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Здравейте, добре дошли в %1!
+
+Изглежда, че това е първият ви път с тази програма.
+Нека конфигурираме нещо заедно.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Искате ли тази програма да се стартира при включване на системата?
+
+Ако често използвате AirPods с този компютър, препоръчва се да натиснете „Да“.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>Искате ли да активирате функцията „ниска аудио латентност“?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Страхотно! Всичко е готово!
+
+Наслаждавайте се.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Можете да ме намерите в системната област</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Кликнете върху иконата, за да видите информацията за батерията, а с десен бутон – за настройки или изход.</translation>
+    </message>
+</context>
+
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Изтегляне на новата версия</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Ръчно изтегляне</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>Ако изтеглянето е бавно или се провали, можете да:</translation>
+    </message>
+</context>
+
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Опа, възникна грешка по време на автоматичната актуализация.
+Моля, изтеглете и инсталирайте новата версия ръчно.</translation>
+    </message>
+</context>
+
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Дневник на промените:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Хей! Намерих налична нова версия!
+
+Текуща версия: %1
+Последна версия: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>Свързване с AirPods</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Моля, изберете вашето AirPods устройство по-долу.</translation>
+    </message>
+</context>
+
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators...</extracomment>
+        <translation>Oleh Hnat|</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Сътрудници в превода:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Библиотеки на трети страни:</translation>
+    </message>
+</context>
+
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Ляво</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Дясно</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Кутия</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>зарежда се</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Налична е нова версия!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Относно</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Изход</translation>
+    </message>
+</context>
+
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>Информация за AirPodsDesktop</translation>
+    </message>
+</context>
+
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Актуализирай сега</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Пропусни тази версия</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Виж изданието</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Напомни ми по-късно</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Не е намерено сдвоено устройство.
+Първо трябва да сдвоите вашите AirPods в настройките на Bluetooth в Windows.</translation>
+    </message>
+</context>
+
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Това поправя проблеми с краткото аудио възпроизвеждане, но може да увеличи разхода на батерията.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>Автоматично поставя на пауза или възобновява медиите, когато AirPods се извадят или поставят в ушите.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Недостъпно</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Изключено</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>Изчакване за свързване</translation>
+    </message>
+</context>
+
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Избери</translation>
+    </message>
+</context>
+
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>Настройки на AirPodsDesktop</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Общи</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Отваряне на директорията с логове</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Максимален обхват на Bluetooth приемане</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>Разкачване на AirPods</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Стартирай при включване на системата</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Език</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Визуално</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Показване на батерията в лентата на задачите</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Деактивирай</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>При ниска батерия</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Винаги</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Като текст</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Като икона</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Показване на батерията върху иконата в системната област</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Функции</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Автоматично разпознаване на ухото</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Ниско закъснение на звука</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Относно</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Отворен код, &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;репозитория&lt;/span&gt;&lt;/a&gt; и лицензирано под &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Авторско право © 2021–2022 SpriteOvO. Всички права запазени.</translation>
+    </message>
+</context>
+</TS>

--- a/Source/Resource/Translation/apd_bg_BG.ts
+++ b/Source/Resource/Translation/apd_bg_BG.ts
@@ -50,7 +50,6 @@ Enjoy it all.</source>
         <translation>Кликнете върху иконата, за да видите информацията за батерията, а с десен бутон – за настройки или изход.</translation>
     </message>
 </context>
-
 <context>
     <name>DownloadWindow</name>
     <message>
@@ -66,7 +65,6 @@ Enjoy it all.</source>
         <translation>Ако изтеглянето е бавно или се провали, можете да:</translation>
     </message>
 </context>
-
 <context>
     <name>Gui::DownloadWindow</name>
     <message>
@@ -76,7 +74,6 @@ Please download and install the new version manually.</source>
 Моля, изтеглете и инсталирайте новата версия ръчно.</translation>
     </message>
 </context>
-
 <context>
     <name>Gui::MainWindow</name>
     <message>
@@ -102,12 +99,11 @@ Latest version: %2%3</source>
         <translation>Моля, изберете вашето AirPods устройство по-долу.</translation>
     </message>
 </context>
-
 <context>
     <name>Gui::SettingsWindow</name>
     <message>
         <source>|</source>
-        <extracomment>To credit translators...</extracomment>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
         <translation>Oleh Hnat|</translation>
     </message>
     <message>
@@ -118,8 +114,11 @@ Latest version: %2%3</source>
         <source>Third-Party Libraries:</source>
         <translation>Библиотеки на трети страни:</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>Запазено устройство (недостъпно)</translation>
+    </message>
 </context>
-
 <context>
     <name>Gui::TrayIcon</name>
     <message>
@@ -154,8 +153,47 @@ Latest version: %2%3</source>
         <source>Quit</source>
         <translation>Изход</translation>
     </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>Бързото свързване е изключено.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>Първо изберете Bluetooth аудиоустройство в настройките.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>Избраното устройство не е достъпно. Включете го или го доближете.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1 вече е свързано.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>Свързване с %1...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 е свързано.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>Времето за свързване с %1 изтече.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>Windows не можа да се свърже с %1.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>Бързо свързване</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Ниска латентност на звука (може да причини шум)</translation>
+    </message>
 </context>
-
 <context>
     <name>MainWindow</name>
     <message>
@@ -163,7 +201,6 @@ Latest version: %2%3</source>
         <translation>Информация за AirPodsDesktop</translation>
     </message>
 </context>
-
 <context>
     <name>QMessageBox</name>
     <message>
@@ -189,13 +226,8 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 Първо трябва да сдвоите вашите AirPods в настройките на Bluetooth в Windows.</translation>
     </message>
 </context>
-
 <context>
     <name>QObject</name>
-    <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Това поправя проблеми с краткото аудио възпроизвеждане, но може да увеличи разхода на батерията.</translation>
-    </message>
     <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Автоматично поставя на пауза или възобновява медиите, когато AirPods се извадят или поставят в ушите.</translation>
@@ -212,8 +244,15 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
         <source>Waiting for Binding</source>
         <translation>Изчакване за свързване</translation>
     </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Поддържа аудиоустройството активно, докато AirPods са свързани, така че кратките звуци да започват веднага. Това може да причини доловим шум и да изразходва повече батерия.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>Щракването върху иконата в системната област свързва избраното устройство, вместо да отваря главния прозорец. Двукратното щракване продължава да го отваря.</translation>
+    </message>
 </context>
-
 <context>
     <name>SelectWindow</name>
     <message>
@@ -221,7 +260,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
         <translation>Избери</translation>
     </message>
 </context>
-
 <context>
     <name>SettingsWindow</name>
     <message>
@@ -301,12 +339,24 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
         <translation>Относно</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Отворен код, &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;репозитория&lt;/span&gt;&lt;/a&gt; и лицензирано под &lt;a href="https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE"&gt;&lt;span style=" text-decoration: underline; color:#0000ff;"&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Отворен код, &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;репозитория&lt;/span&gt;&lt;/a&gt; и лицензирано под &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
         <translation>Авторско право © 2021–2022 SpriteOvO. Всички права запазени.</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>Свързване на избраното устройство с щракване върху иконата в системната област</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>Сдвоеното Bluetooth аудиоустройство, с което се осъществява връзка при щракване върху иконата в системната област.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_de_DE.ts
+++ b/Source/Resource/Translation/apd_de_DE.ts
@@ -14,7 +14,7 @@ This seems to be your first time using this program.
 Let&apos;s configure something together.</source>
         <translation>Hallo, willkommen bei %1!
 
-Anscheinend benutzt du dieses Programm zum ersten mal.
+Anscheinend benutzt du dieses Programm zum ersten Mal.
 Lass uns zusammen ein paar Einstellungen vornehmen.</translation>
     </message>
     <message>
@@ -116,7 +116,7 @@ Neueste Version: %2%3</translation>
     </message>
     <message>
         <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>Gespeichertes Gerät (nicht verfügbar)</translation>
     </message>
 </context>
 <context>
@@ -159,39 +159,39 @@ Neueste Version: %2%3</translation>
     </message>
     <message>
         <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Schnellverbindung ist deaktiviert.</translation>
     </message>
     <message>
         <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
+        <translation>Wähle zuerst in den Einstellungen ein Bluetooth-Audiogerät aus.</translation>
     </message>
     <message>
         <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das ausgewählte Gerät ist nicht verfügbar. Schalte es ein oder bringe es in Reichweite.</translation>
     </message>
     <message>
         <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ist bereits verbunden.</translation>
     </message>
     <message>
         <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
+        <translation>Verbindung mit %1 wird hergestellt...</translation>
     </message>
     <message>
         <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 ist verbunden.</translation>
     </message>
     <message>
         <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeitüberschreitung beim Verbinden mit %1.</translation>
     </message>
     <message>
         <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows konnte keine Verbindung mit %1 herstellen.</translation>
     </message>
     <message>
         <source>Quick connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Schnellverbindung</translation>
     </message>
 </context>
 <context>
@@ -213,7 +213,7 @@ Neueste Version: %2%3</translation>
     </message>
     <message>
         <source>View release</source>
-        <translation>Release anzeigen</translation>
+        <translation>Versionshinweise anzeigen</translation>
     </message>
     <message>
         <source>Remind me later</source>
@@ -223,7 +223,7 @@ Neueste Version: %2%3</translation>
         <source>No paired device found.
 You need to pair your AirPods in Windows Bluetooth Settings first.</source>
         <translation>Kein gekoppeltes Gerät gefunden.
-Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</translation>
+Kopple deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</translation>
     </message>
 </context>
 <context>
@@ -250,7 +250,7 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ein Klick auf das Symbol im Infobereich verbindet das ausgewählte Gerät, anstatt das Hauptfenster zu öffnen. Ein Doppelklick öffnet es weiterhin.</translation>
     </message>
 </context>
 <context>
@@ -280,7 +280,7 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>Unbind AirPods</source>
-        <translation>AirPods trennen</translation>
+        <translation>AirPods entkoppeln</translation>
     </message>
     <message>
         <source>Launch when system starts</source>
@@ -292,11 +292,11 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>Visual</source>
-        <translation>Visuell</translation>
+        <translation>Darstellung</translation>
     </message>
     <message>
         <source>Display battery on tray icon</source>
-        <translation>Batterie-Icon im Infobereich der Taskleiste anzeigen</translation>
+        <translation>Akkustand im Infobereich anzeigen</translation>
     </message>
     <message>
         <source>Disable</source>
@@ -304,7 +304,7 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>When low battery</source>
-        <translation>Bei niedrigem Batteriestand</translation>
+        <translation>Bei niedrigem Akkustand</translation>
     </message>
     <message>
         <source>Always</source>
@@ -320,7 +320,7 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>Low audio latency</source>
-        <translation>Niedrige Audio-Latenz</translation>
+        <translation>Niedrige Audiolatenz</translation>
     </message>
     <message>
         <source>About</source>
@@ -348,15 +348,15 @@ Bitte verbinde deine AirPods zuerst in den Windows Bluetooth-Einstellungen.</tra
     </message>
     <message>
         <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgewähltes Gerät per Klick auf das Symbol im Infobereich verbinden</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerät</translation>
     </message>
     <message>
         <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das gekoppelte Bluetooth-Audiogerät, das beim Klicken auf das Symbol im Infobereich verbunden wird.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_fr_FR.ts
+++ b/Source/Resource/Translation/apd_fr_FR.ts
@@ -116,7 +116,7 @@ Dernière version : %2%3</translation>
     </message>
     <message>
         <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>Appareil enregistré (indisponible)</translation>
     </message>
 </context>
 <context>
@@ -159,39 +159,39 @@ Dernière version : %2%3</translation>
     </message>
     <message>
         <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>La connexion rapide est désactivée.</translation>
     </message>
     <message>
         <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez d&apos;abord un périphérique audio Bluetooth dans les paramètres.</translation>
     </message>
     <message>
         <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;appareil sélectionné n&apos;est pas disponible. Allumez-le ou rapprochez-le.</translation>
     </message>
     <message>
         <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 est déjà connecté.</translation>
     </message>
     <message>
         <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connexion à %1...</translation>
     </message>
     <message>
         <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 est connecté.</translation>
     </message>
     <message>
         <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le délai de connexion à %1 a expiré.</translation>
     </message>
     <message>
         <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows n&apos;a pas pu se connecter à %1.</translation>
     </message>
     <message>
         <source>Quick connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Connexion rapide</translation>
     </message>
 </context>
 <context>
@@ -230,7 +230,7 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     <name>QObject</name>
     <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
-        <translation>Il met automatiquement en pause ou reprend le média lorsque vous retirez ou remettez vos AirPods dans vos oreilles.</translation>
+        <translation>La lecture est automatiquement mise en pause ou reprise lorsque vous retirez ou remettez vos AirPods dans vos oreilles.</translation>
     </message>
     <message>
         <source>Unavailable</source>
@@ -250,7 +250,7 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     </message>
     <message>
         <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Un clic sur l&apos;icône de la zone de notification connecte l&apos;appareil sélectionné au lieu d&apos;ouvrir la fenêtre principale. Un double-clic continue de l&apos;ouvrir.</translation>
     </message>
 </context>
 <context>
@@ -272,11 +272,11 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     </message>
     <message>
         <source>Open logs directory</source>
-        <translation>Ouvrir le répertoire des journaux</translation>
+        <translation>Ouvrir le dossier des journaux</translation>
     </message>
     <message>
         <source>Bluetooth maximum receiving range</source>
-        <translation>Portée maximale de la réception Bluetooth</translation>
+        <translation>Portée Bluetooth maximale</translation>
     </message>
     <message>
         <source>Unbind AirPods</source>
@@ -292,7 +292,7 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     </message>
     <message>
         <source>Visual</source>
-        <translation>Visuel</translation>
+        <translation>Apparence</translation>
     </message>
     <message>
         <source>Display battery on taskbar</source>
@@ -328,7 +328,7 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     </message>
     <message>
         <source>Automatic ear detection</source>
-        <translation>Détection automatique du port</translation>
+        <translation>Détection automatique des oreilles</translation>
     </message>
     <message>
         <source>Low audio latency</source>
@@ -348,15 +348,15 @@ Vous devez d&apos;abord appairer vos AirPods dans les paramètres Bluetooth de W
     </message>
     <message>
         <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecter l&apos;appareil sélectionné en cliquant sur l&apos;icône de la zone de notification</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Appareil</translation>
     </message>
     <message>
         <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le périphérique audio Bluetooth associé qui sera connecté lors d&apos;un clic sur l&apos;icône de la zone de notification.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_it_IT.ts
+++ b/Source/Resource/Translation/apd_it_IT.ts
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="it_IT">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>Il formato delle impostazioni è un po&apos; cambiato e ha bisogno di essere riconfigurato.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Ciao, benvenuti a %1 !
+
+Sembra sia la prima volta che usi questo programma.
+Configuriamo qualcosa insieme.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Vuoi che questo programma si apra all&apos;avvio del sistema?
+
+Se utilizzi spesso le AirPods su questo computer è consigliabile cliccare su &quot;Sì&quot;.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>Vuoi attivare la funzionalità &quot;audio a bassa latenza&quot;?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Perfetto! È tutto pronto!
+
+Divertiti.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Mi puoi trovare nella barra di sistema</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Clicca l&apos;icona per visualizzare le informazioni sulla batteria. Clicca con il tasto destro per personalizzare le impostazioni o uscire.</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Scarica la nuova versione</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Scarica manualmente</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>Se il download è lento o fallisce puoi:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Oops,c&apos;è stato un errore durante l&apos;aggiornamento automatico.
+Per favore scarica e installa manualmente la nuova versione.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Change log:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Hei! Ho trovato una nuova versione disponibile!
+
+Versione attuale: %1
+L&apos;ultima versione: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>Abbina le AirPods</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Per favore seleziona qui sotto il tuo dispositivo AirPods.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
+        <translatorcomment>Grazie della possibilità, mi sono divertito.</translatorcomment>
+        <translation>Luigi Oria|</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Contributori alla traduzione:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Librerie di terze parti:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Sinistra</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Destra</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Custodia</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>in carica</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Nuova versione disponibile!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Impostazioni</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Esci</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>Informazioni su AirPodsDesktop</translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Aggiorna adesso</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Salta questa versione</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Guarda la versione</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Ricordamelo dopo</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Nessun dispositivo abbinato trovato.
+Devi prima abbinare le tue AirPods nelle impostazioni Bluetooth di Windows.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Risolve il problema della riproduzione degli audio brevi, ma può aumentare il consumo di batteria.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>Mette automaticamente in pausa o riavvia la riproduzione di un contenuto quando.togli o metti le tue Airpods nelle orecchie.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Non disponibile</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Disconnesso</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>In attessa dell&apos;abbinamento</translation>
+    </message>
+</context>
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Seleziona</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>Impostazioni di AirPodsDesktop</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Apri la cartella dei logs</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Portata massima della ricezione bluetooth</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>Disabbina AirPods</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Apri all&apos;avvio del sistema</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Lingua</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Vista</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Mostra la batteria sulla taskbar</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Disabilita</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>Quando la batteria è bassa</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Come testo</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Come icona</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Mostra la batteria nell&apos;area di notifica</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Funzionalità</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Rilevamento automatico dell&apos;orecchio</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Audio a bassa latenza</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Archivio&lt;/span&gt;&lt;/a&gt; open source e licenza di &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Copyright © 2021-2022 SpriteOvO. Tutti i diritti riservati.</translation>
+    </message>
+</context>
+</TS>

--- a/Source/Resource/Translation/apd_it_IT.ts
+++ b/Source/Resource/Translation/apd_it_IT.ts
@@ -115,6 +115,10 @@ L&apos;ultima versione: %2%3</translation>
         <source>Third-Party Libraries:</source>
         <translation>Librerie di terze parti:</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>Dispositivo salvato (non disponibile)</translation>
+    </message>
 </context>
 <context>
     <name>Gui::TrayIcon</name>
@@ -149,6 +153,46 @@ L&apos;ultima versione: %2%3</translation>
     <message>
         <source>Quit</source>
         <translation>Esci</translation>
+    </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>La connessione rapida è disattivata.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>Seleziona prima un dispositivo audio Bluetooth nelle Impostazioni.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>Il dispositivo selezionato non è disponibile. Accendilo o avvicinalo.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1 è già connesso.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>Connessione a %1...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 connesso.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>Tempo scaduto durante la connessione a %1.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>Windows non è riuscito a connettersi a %1.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>Connessione rapida</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Bassa latenza audio (potrebbe causare fruscii)</translation>
     </message>
 </context>
 <context>
@@ -186,10 +230,6 @@ Devi prima abbinare le tue AirPods nelle impostazioni Bluetooth di Windows.</tra
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Risolve il problema della riproduzione degli audio brevi, ma può aumentare il consumo di batteria.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Mette automaticamente in pausa o riavvia la riproduzione di un contenuto quando.togli o metti le tue Airpods nelle orecchie.</translation>
     </message>
@@ -204,6 +244,14 @@ Devi prima abbinare le tue AirPods nelle impostazioni Bluetooth di Windows.</tra
     <message>
         <source>Waiting for Binding</source>
         <translation>In attessa dell&apos;abbinamento</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Mantiene attivo il dispositivo audio mentre gli AirPods sono connessi, così i suoni brevi iniziano subito. Potrebbe produrre un fruscio udibile e consumare più batteria.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>Un clic sull&apos;icona nell&apos;area di notifica connette il dispositivo selezionato invece di aprire la finestra principale. Un doppio clic continua ad aprirla.</translation>
     </message>
 </context>
 <context>
@@ -298,6 +346,18 @@ Devi prima abbinare le tue AirPods nelle impostazioni Bluetooth di Windows.</tra
     <message>
         <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
         <translation>Copyright © 2021-2022 SpriteOvO. Tutti i diritti riservati.</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>Connetti il dispositivo selezionato con un clic sull&apos;icona nell&apos;area di notifica</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Dispositivo</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>Il dispositivo audio Bluetooth associato che viene connesso facendo clic sull&apos;icona nell&apos;area di notifica.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_ja_JP.ts
+++ b/Source/Resource/Translation/apd_ja_JP.ts
@@ -116,7 +116,7 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>保存済みのデバイス（利用不可）</translation>
     </message>
 </context>
 <context>
@@ -155,43 +155,43 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Low audio latency (may cause hiss)</source>
-        <translation>低音声レイテンシー（ノイズが発生する場合があります）</translation>
+        <translation>低遅延モード（ノイズが発生する場合があります）</translation>
     </message>
     <message>
         <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>クイック接続は無効です。</translation>
     </message>
     <message>
         <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
+        <translation>まず設定で Bluetooth オーディオデバイスを選択してください。</translation>
     </message>
     <message>
         <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
+        <translation>選択したデバイスは利用できません。電源を入れるか、通信範囲内に移動してください。</translation>
     </message>
     <message>
         <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 はすでに接続されています。</translation>
     </message>
     <message>
         <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 に接続しています...</translation>
     </message>
     <message>
         <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 に接続しました。</translation>
     </message>
     <message>
         <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 への接続がタイムアウトしました。</translation>
     </message>
     <message>
         <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Windows は %1 に接続できませんでした。</translation>
     </message>
     <message>
         <source>Quick connect</source>
-        <translation type="unfinished"></translation>
+        <translation>クイック接続</translation>
     </message>
 </context>
 <context>
@@ -222,8 +222,8 @@ Latest version: %2%3</source>
     <message>
         <source>No paired device found.
 You need to pair your AirPods in Windows Bluetooth Settings first.</source>
-        <translation>ペアリングされたデバイスが見つかりません。
-先にWindowsのBluetooth設定からAirPodsとペアリングする必要があります。</translation>
+        <translation>ペアリング済みのデバイスが見つかりません。
+先に Windows の Bluetooth 設定で AirPods をペアリングしてください。</translation>
     </message>
 </context>
 <context>
@@ -250,7 +250,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
+        <translation>通知領域のアイコンをクリックすると、メインウィンドウを開かずに選択したデバイスへ接続します。ダブルクリックすると、引き続きメインウィンドウが開きます。</translation>
     </message>
 </context>
 <context>
@@ -280,7 +280,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Unbind AirPods</source>
-        <translation>AirPodsとの接続を解除</translation>
+        <translation>AirPods の登録を解除</translation>
     </message>
     <message>
         <source>Launch when system starts</source>
@@ -292,7 +292,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Visual</source>
-        <translation>見た目</translation>
+        <translation>表示</translation>
     </message>
     <message>
         <source>Display battery on tray icon</source>
@@ -348,15 +348,15 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
+        <translation>通知領域のアイコンをクリックして選択したデバイスに接続</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>デバイス</translation>
     </message>
     <message>
         <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>通知領域のアイコンをクリックしたときに接続する、ペアリング済みの Bluetooth オーディオデバイスです。</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_ko_KR.ts
+++ b/Source/Resource/Translation/apd_ko_KR.ts
@@ -5,23 +5,23 @@
     <name>ApdApplication</name>
     <message>
         <source>Settings format has changed a bit and needs to be reconfigured.</source>
-        <translation>설정이 변경되어 다시 구성해야 합니다.</translation>
+        <translation>설정 형식이 변경되어 재구성이 필요합니다.</translation>
     </message>
     <message>
         <source>Hello, welcome to %1!
 
 This seems to be your first time using this program.
 Let&apos;s configure something together.</source>
-        <translation>안녕하세요, %1!
+        <translation>%1에 오신 것을 환영합니다!
 
-이 프로그램을 처음 사용하시는군요!
-함께 설정해 봅시다.</translation>
+이 프로그램을 처음 사용하시는 것 같습니다.
+함께 설정을 진행해 보겠습니다.</translation>
     </message>
     <message>
         <source>Do you want this program to launch when the system starts?
 
 If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
-        <translation>시스템을 시작할 때 이 프로그램을 실행하시겠습니까?
+        <translation>시스템 시작 시 이 프로그램을 실행하시겠습니까?
 
 이 컴퓨터에서 AirPods을 자주 사용한다면 &quot;예&quot;를 클릭하는 것이 좋습니다.</translation>
     </message>
@@ -29,7 +29,7 @@ If you frequently use AirPods with this computer, it is recommended that you cli
         <source>Do you want to enable the &quot;low audio latency&quot; feature?
 
 %1</source>
-        <translation>&quot;낮은 오디오 지연&quot; 기능을 사용하시겠습니까?
+        <translation>&quot;오디오 지연 최소화&quot;를 활성화하시겠습니까?
 
 %1</translation>
     </message>
@@ -37,17 +37,17 @@ If you frequently use AirPods with this computer, it is recommended that you cli
         <source>Great! Everything is ready!
 
 Enjoy it all.</source>
-        <translation>좋아요! 모든 준비가 되었습니다.
+        <translation>모든 준비가 완료되었습니다!
 
-모두 즐기세요.</translation>
+이제 마음껏 즐겨보세요.</translation>
     </message>
     <message>
         <source>You can find me in the system tray</source>
-        <translation>시스템 트레이에서 찾을 수 있습니다</translation>
+        <translation>시스템 트레이에서 확인하실 수 있습니다.</translation>
     </message>
     <message>
         <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
-        <translation>아이콘을 클릭하면 배터리 정보를 확인할 수 있습니다. 설정을 변경하거나 종료하려면 마우스 오른쪽 버튼을 클릭하세요.</translation>
+        <translation>아이콘을 클릭해 배터리 정보를 확인해 보세요. 설정을 변경하거나 종료하려면 우클릭합니다.</translation>
     </message>
 </context>
 <context>
@@ -62,7 +62,7 @@ Enjoy it all.</source>
     </message>
     <message>
         <source>If the download is slow or fails, you can:</source>
-        <translation>다운로드가 느리거나 실패하는 경우 다음을 시도할 수 있습니다:</translation>
+        <translation>다운로드 속도가 느리거나 실패할 경우</translation>
     </message>
 </context>
 <context>
@@ -70,8 +70,8 @@ Enjoy it all.</source>
     <message>
         <source>Oops, an error occurred during the automatic update.
 Please download and install the new version manually.</source>
-        <translation>앗, 자동 업데이트 중에 오류가 발생했습니다.
-새 버전을 수동으로 내려받아 설치해주세요.</translation>
+        <translation>업데이트를 완료할 수 없습니다.
+최신 버전을 직접 다운로드하여 설치할 수 있습니다.</translation>
     </message>
 </context>
 <context>
@@ -85,18 +85,18 @@ Please download and install the new version manually.</source>
 
 Current version: %1
 Latest version: %2%3</source>
-        <translation>새로운 버전을 찾았습니다!
+        <translation>새로운 버전을 사용할 수 있습니다.
 
 현재 버전: %1
 최신 버전: %2%3</translation>
     </message>
     <message>
         <source>Bind to AirPods</source>
-        <translation>AirPods 연결</translation>
+        <translation>AirPods에 연결하기</translation>
     </message>
     <message>
         <source>Please select your AirPods device below.</source>
-        <translation>아래에서 AirPods 장치를 선택하세요.</translation>
+        <translation>아래에서 AirPods를 선택합니다.</translation>
     </message>
 </context>
 <context>
@@ -104,19 +104,15 @@ Latest version: %2%3</source>
     <message>
         <source>|</source>
         <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
-        <translation>|</translation>
+        <translation>Resi-le</translation>
     </message>
     <message>
         <source>Translation Contributors:</source>
-        <translation>번역 기여자:</translation>
+        <translation>번역 기여</translation>
     </message>
     <message>
         <source>Third-Party Libraries:</source>
-        <translation>서드 파티 라이브러리:</translation>
-    </message>
-    <message>
-        <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>오픈 소스 및 타사 라이브러리 정보</translation>
     </message>
 </context>
 <context>
@@ -131,15 +127,15 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Case</source>
-        <translation>케이스</translation>
+        <translation>충전 케이스</translation>
     </message>
     <message>
         <source>charging</source>
-        <translation>충전 중</translation>
+        <translation>충전중</translation>
     </message>
     <message>
         <source>New version available!</source>
-        <translation>새 버전을 사용할 수 있습니다!</translation>
+        <translation>새로운 버전을 사용할 수 있습니다.</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -152,46 +148,6 @@ Latest version: %2%3</source>
     <message>
         <source>Quit</source>
         <translation>종료</translation>
-    </message>
-    <message>
-        <source>Low audio latency (may cause hiss)</source>
-        <translation>낮은 오디오 지연 시간(잡음이 발생할 수 있음)</translation>
-    </message>
-    <message>
-        <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quick connect</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -213,24 +169,28 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>View release</source>
-        <translation>버전 보기</translation>
+        <translation>업데이트 내용 보기</translation>
     </message>
     <message>
         <source>Remind me later</source>
-        <translation>나중에 알림</translation>
+        <translation>나중에 하기</translation>
     </message>
     <message>
         <source>No paired device found.
 You need to pair your AirPods in Windows Bluetooth Settings first.</source>
-        <translation>페어링된 장치를 찾을 수 없습니다.
-먼저 Windows Bluetooth 설정에서 AirPods을 페어링해야 합니다.</translation>
+        <translation>페어링된 AirPods이 없습니다.
+Windows의 Bluetooth 설정에서 AirPods을 페어링해야 합니다.</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>오디오 재생 문제를 해결합니다. 단, 배터리 소모가 증가할 수 있습니다.</translation>
+    </message>
+    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
-        <translation>AirPods을 빼거나 귀에 넣으면 자동으로 미디어를 일시 중지하거나 다시 시작합니다.</translation>
+        <translation>AirPods을 귀에서 빼거나 착용하면 미디어를 자동으로 일시 정지하거나 재개합니다.</translation>
     </message>
     <message>
         <source>Unavailable</source>
@@ -238,19 +198,11 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Disconnected</source>
-        <translation>연결 끊김</translation>
+        <translation>연결되지 않음</translation>
     </message>
     <message>
         <source>Waiting for Binding</source>
         <translation>연결 대기 중</translation>
-    </message>
-    <message>
-        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
-        <translation>AirPods이 연결되어 있는 동안 오디오 장치를 활성 상태로 유지하여 짧은 소리가 즉시 재생되도록 합니다. 잡음이 들리거나 배터리 사용량이 증가할 수 있습니다.</translation>
-    </message>
-    <message>
-        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -276,11 +228,11 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Bluetooth maximum receiving range</source>
-        <translation>블루투스 최대 수신 범위</translation>
+        <translation>Bluetooth 최대 수신 거리</translation>
     </message>
     <message>
         <source>Unbind AirPods</source>
-        <translation>AirPods 연결 해제</translation>
+        <translation>AirPods 연결해제</translation>
     </message>
     <message>
         <source>Launch when system starts</source>
@@ -300,7 +252,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Disable</source>
-        <translation>사용 안 함</translation>
+        <translation>안 함</translation>
     </message>
     <message>
         <source>When low battery</source>
@@ -316,11 +268,11 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Automatic ear detection</source>
-        <translation>자동 착용 감지</translation>
+        <translation>자동으로 착용 감지</translation>
     </message>
     <message>
         <source>Low audio latency</source>
-        <translation>낮은 오디오 지연</translation>
+        <translation>오디오 지연 최소화</translation>
     </message>
     <message>
         <source>About</source>
@@ -328,35 +280,23 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;오픈 소스 저장소&lt;/span&gt;&lt;/a&gt;에서 소스 코드를 확인할 수 있으며 &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt; 라이선스로 배포됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;오픈 소스 &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;저장소&lt;/span&gt;&lt;/a&gt; 및 &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot;text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;에 따라 라이센스가 부여됨.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
-        <translation>Copyright © 2021-2022 SpriteOvO. 모든 권리 보유.</translation>
+        <translation>Copyright © 2021-2022 모든 저작권은 SpriteOvO에게 있습니다.</translation>
     </message>
     <message>
         <source>Display battery on taskbar</source>
-        <translation>작업 표시줄에 배터리 잔량 표시</translation>
+        <translation>작업 표시줄에 배터리 상태 표시</translation>
     </message>
     <message>
         <source>As text</source>
-        <translation>텍스트로 표시</translation>
+        <translation>텍스트</translation>
     </message>
     <message>
         <source>As icon</source>
-        <translation>아이콘으로 표시</translation>
-    </message>
-    <message>
-        <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Device</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>아이콘</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_ko_KR.ts
+++ b/Source/Resource/Translation/apd_ko_KR.ts
@@ -114,6 +114,10 @@ Latest version: %2%3</source>
         <source>Third-Party Libraries:</source>
         <translation>오픈 소스 및 타사 라이브러리 정보</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>저장된 기기(사용 불가)</translation>
+    </message>
 </context>
 <context>
     <name>Gui::TrayIcon</name>
@@ -148,6 +152,46 @@ Latest version: %2%3</source>
     <message>
         <source>Quit</source>
         <translation>종료</translation>
+    </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>빠른 연결이 비활성화되어 있습니다.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>먼저 설정에서 Bluetooth 오디오 기기를 선택하세요.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>선택한 기기를 사용할 수 없습니다. 기기를 켜거나 가까이 가져오세요.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1은(는) 이미 연결되어 있습니다.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>%1에 연결하는 중...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 연결됨.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>%1 연결 시간이 초과되었습니다.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>Windows에서 %1에 연결하지 못했습니다.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>빠른 연결</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>오디오 지연 최소화(잡음이 발생할 수 있음)</translation>
     </message>
 </context>
 <context>
@@ -185,10 +229,6 @@ Windows의 Bluetooth 설정에서 AirPods을 페어링해야 합니다.</transla
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>오디오 재생 문제를 해결합니다. 단, 배터리 소모가 증가할 수 있습니다.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>AirPods을 귀에서 빼거나 착용하면 미디어를 자동으로 일시 정지하거나 재개합니다.</translation>
     </message>
@@ -203,6 +243,14 @@ Windows의 Bluetooth 설정에서 AirPods을 페어링해야 합니다.</transla
     <message>
         <source>Waiting for Binding</source>
         <translation>연결 대기 중</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>AirPods이 연결된 동안 오디오 기기를 활성 상태로 유지하여 짧은 소리가 즉시 재생되도록 합니다. 잡음이 들리거나 배터리 사용량이 증가할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>트레이 아이콘을 클릭하면 기본 창을 여는 대신 선택한 기기에 연결합니다. 두 번 클릭하면 기본 창이 열립니다.</translation>
     </message>
 </context>
 <context>
@@ -297,6 +345,18 @@ Windows의 Bluetooth 설정에서 AirPods을 페어링해야 합니다.</transla
     <message>
         <source>As icon</source>
         <translation>아이콘</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>트레이 아이콘을 클릭하여 선택한 기기에 연결</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>기기</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>트레이 아이콘 클릭 시 연결할 페어링된 Bluetooth 오디오 기기입니다.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_pt_BR.ts
+++ b/Source/Resource/Translation/apd_pt_BR.ts
@@ -112,11 +112,11 @@ Versão atual: %1
     </message>
     <message>
         <source>Third-Party Libraries:</source>
-        <translation>Bibliotecas de Terceiros:</translation>
+        <translation>Bibliotecas de terceiros:</translation>
     </message>
     <message>
         <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo salvo (indisponível)</translation>
     </message>
 </context>
 <context>
@@ -155,43 +155,43 @@ Versão atual: %1
     </message>
     <message>
         <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>A conexão rápida está desativada.</translation>
     </message>
     <message>
         <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
+        <translation>Primeiro, escolha um dispositivo de áudio Bluetooth nas Configurações.</translation>
     </message>
     <message>
         <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
+        <translation>O dispositivo selecionado não está disponível. Ligue-o ou aproxime-o.</translation>
     </message>
     <message>
         <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 já está conectado.</translation>
     </message>
     <message>
         <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
+        <translation>Conectando a %1...</translation>
     </message>
     <message>
         <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 conectado.</translation>
     </message>
     <message>
         <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>O tempo de conexão com %1 se esgotou.</translation>
     </message>
     <message>
         <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>O Windows não conseguiu se conectar a %1.</translation>
     </message>
     <message>
         <source>Quick connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Conexão rápida</translation>
     </message>
     <message>
         <source>Low audio latency (may cause hiss)</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixa latência de áudio (pode causar chiado)</translation>
     </message>
 </context>
 <context>
@@ -213,7 +213,7 @@ Versão atual: %1
     </message>
     <message>
         <source>View release</source>
-        <translation>Ver versão</translation>
+        <translation>Ver notas da versão</translation>
     </message>
     <message>
         <source>Remind me later</source>
@@ -246,11 +246,11 @@ Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Window
     </message>
     <message>
         <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mantém o dispositivo de áudio ativo enquanto os AirPods estão conectados para que sons curtos sejam reproduzidos imediatamente. Isso pode causar chiado audível e aumentar o consumo da bateria.</translation>
     </message>
     <message>
         <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Um clique no ícone da bandeja conecta o dispositivo selecionado em vez de abrir a janela principal. Um clique duplo continua abrindo-a.</translation>
     </message>
 </context>
 <context>
@@ -272,7 +272,7 @@ Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Window
     </message>
     <message>
         <source>Open logs directory</source>
-        <translation>Abrir diretório de logs</translation>
+        <translation>Abrir pasta de logs</translation>
     </message>
     <message>
         <source>Bluetooth maximum receiving range</source>
@@ -292,7 +292,7 @@ Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Window
     </message>
     <message>
         <source>Visual</source>
-        <translation>Visual</translation>
+        <translation>Aparência</translation>
     </message>
     <message>
         <source>Display battery on taskbar</source>
@@ -328,7 +328,7 @@ Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Window
     </message>
     <message>
         <source>Automatic ear detection</source>
-        <translation>Detecção automática de uso</translation>
+        <translation>Detecção automática de ouvido</translation>
     </message>
     <message>
         <source>Low audio latency</source>
@@ -348,15 +348,15 @@ Você precisa emparelhar seus AirPods nas Configurações de Bluetooth do Window
     </message>
     <message>
         <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
+        <translation>Conectar o dispositivo selecionado ao clicar no ícone da bandeja</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo</translation>
     </message>
     <message>
         <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>O dispositivo de áudio Bluetooth emparelhado que será conectado ao clicar no ícone da bandeja.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_pt_PT.ts
+++ b/Source/Resource/Translation/apd_pt_PT.ts
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_PT">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>O formato das definições mudou um pouco e precisa de ser reconfigurado.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Olá, bem-vindo ao %1!
+
+Esta parece ser a sua primeira vez a utilizar este programa.
+Vamos configurar algo juntos.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Pretende que este programa seja iniciado quando o sistema for inicializado?
+
+Se utiliza os seus AirPods com frequência neste computador, é recomendado clicar em &quot;Sim&quot;.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>Deseja ativar a funcionalidade de &quot;baixa latência de áudio&quot;?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Perfeito! Está tudo pronto!
+
+Aproveite.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Pode encontrar-me na barra de tarefas</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Clique no ícone para visualizar as informações da bateria, clique com o botão direito do rato para personalizar as definições ou para sair.</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Descarregue a nova versão</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Descarregue manualmente</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>Se o download estiver lento ou se falhar, pode:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Ups, ocorreu um erro durante a atualização automática.
+Descarregue e instale a nova versão manualmente.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Registo de modificações:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Uma nova versão encontra-se disponível!
+
+Versão atual: %1
+Última versão: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>Ligar-se aos AirPods</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Selecione os seus AirPods abaixo.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
+        <translation>Francisco Carmo</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Colaboradores de tradução:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Bibliotecas de terceiros:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Esquerda</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Direita</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Caixa</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>a carregar</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Nova versão disponível!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Configurações</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>AirPodsDesktop informações</translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Atualizar agora</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Saltar esta versão</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Ver versão</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Lembrar-me mais tarde</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Nenhum dispositivo emparelhado foi encontrado.
+Precisa primeiro de emparelhar os seus AirPods nas definições de Bluetooth do Windows.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Corrige problemas de reprodução de áudio curtos, mas pode aumentar o consumo da bateria.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>Faz pausa ou retoma automaticamente os media quando os seus AirPods são retirados ou colocados nos ouvidos.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Desconectado</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>À espera de ligação</translation>
+    </message>
+</context>
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Selecionar</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>AirPodsDesktop configurações</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Abrir a pasta de registos</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Alcance máximo de receção Bluetooth</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>Desconectar AirPods</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Iniciar quando o sistema inicia</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Visual</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Mostar a bateria na barra de tarefas</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Desativar</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>Quando a bateria está fraca</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Como texto</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Como ícone</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Exibir bateria no ícone da barra</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Funcionalidades</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Detecção automática de ouvidos</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Baixa latência de áudio</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Acerca</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Código aberto &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repositório&lt;/span&gt;&lt;/a&gt; e licenciado sob &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Copyright © 2021-2022 SpriteOvO. Todos os direitos reservados.</translation>
+    </message>
+</context>
+</TS>

--- a/Source/Resource/Translation/apd_pt_PT.ts
+++ b/Source/Resource/Translation/apd_pt_PT.ts
@@ -114,6 +114,10 @@ Versão atual: %1
         <source>Third-Party Libraries:</source>
         <translation>Bibliotecas de terceiros:</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>Dispositivo guardado (indisponível)</translation>
+    </message>
 </context>
 <context>
     <name>Gui::TrayIcon</name>
@@ -148,6 +152,46 @@ Versão atual: %1
     <message>
         <source>Quit</source>
         <translation>Sair</translation>
+    </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>A ligação rápida está desativada.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>Escolha primeiro um dispositivo de áudio Bluetooth nas Definições.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>O dispositivo selecionado não está disponível. Ligue-o ou aproxime-o.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1 já está ligado.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>A ligar a %1...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 ligado.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>A ligação a %1 excedeu o tempo limite.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>O Windows não conseguiu ligar-se a %1.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>Ligação rápida</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Baixa latência de áudio (pode causar ruído)</translation>
     </message>
 </context>
 <context>
@@ -185,10 +229,6 @@ Precisa primeiro de emparelhar os seus AirPods nas definições de Bluetooth do 
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Corrige problemas de reprodução de áudio curtos, mas pode aumentar o consumo da bateria.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Faz pausa ou retoma automaticamente os media quando os seus AirPods são retirados ou colocados nos ouvidos.</translation>
     </message>
@@ -203,6 +243,14 @@ Precisa primeiro de emparelhar os seus AirPods nas definições de Bluetooth do 
     <message>
         <source>Waiting for Binding</source>
         <translation>À espera de ligação</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Mantém o dispositivo de áudio ativo enquanto os AirPods estão ligados, para que os sons curtos sejam reproduzidos imediatamente. Isto pode produzir ruído audível e consumir mais bateria.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>Um clique no ícone da área de notificação liga o dispositivo selecionado em vez de abrir a janela principal. Um duplo clique continua a abri-la.</translation>
     </message>
 </context>
 <context>
@@ -297,6 +345,18 @@ Precisa primeiro de emparelhar os seus AirPods nas definições de Bluetooth do 
     <message>
         <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
         <translation>Copyright © 2021-2022 SpriteOvO. Todos os direitos reservados.</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>Ligar o dispositivo selecionado ao clicar no ícone da área de notificação</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Dispositivo</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>O dispositivo de áudio Bluetooth emparelhado que será ligado ao clicar no ícone da área de notificação.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_ru_RU.ts
+++ b/Source/Resource/Translation/apd_ru_RU.ts
@@ -5,7 +5,7 @@
     <name>ApdApplication</name>
     <message>
         <source>Settings format has changed a bit and needs to be reconfigured.</source>
-        <translation>Формат настройки был изменен и нуждается в перенастройке.</translation>
+        <translation>Формат настроек изменился, поэтому их необходимо настроить заново.</translation>
     </message>
     <message>
         <source>Hello, welcome to %1!
@@ -29,7 +29,7 @@ If you frequently use AirPods with this computer, it is recommended that you cli
         <source>Do you want to enable the &quot;low audio latency&quot; feature?
 
 %1</source>
-        <translation>Вы хотите включить функцию &quot;низкой задержки звука&quot;?
+        <translation>Включить функцию «Низкая задержка звука»?
 
 %1</translation>
     </message>
@@ -116,7 +116,7 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Saved device (not available)</source>
-        <translation type="unfinished"></translation>
+        <translation>Сохраненное устройство (недоступно)</translation>
     </message>
 </context>
 <context>
@@ -131,7 +131,7 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Case</source>
-        <translation>Кейс</translation>
+        <translation>Футляр</translation>
     </message>
     <message>
         <source>charging</source>
@@ -159,46 +159,46 @@ Latest version: %2%3</source>
     </message>
     <message>
         <source>Quick connection is disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Быстрое подключение отключено.</translation>
     </message>
     <message>
         <source>Choose a Bluetooth audio device in Settings first.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сначала выберите аудиоустройство Bluetooth в настройках.</translation>
     </message>
     <message>
         <source>The selected device is not available. Turn it on or bring it into range.</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбранное устройство недоступно. Включите его или переместите в зону действия.</translation>
     </message>
     <message>
         <source>%1 is already connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 уже подключено.</translation>
     </message>
     <message>
         <source>Connecting to %1...</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключение к %1...</translation>
     </message>
     <message>
         <source>%1 connected.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 подключено.</translation>
     </message>
     <message>
         <source>Connection to %1 timed out.</source>
-        <translation type="unfinished"></translation>
+        <translation>Время ожидания подключения к %1 истекло.</translation>
     </message>
     <message>
         <source>Windows could not connect to %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось подключиться к %1 в Windows.</translation>
     </message>
     <message>
         <source>Quick connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Быстрое подключение</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <source>AirPodsDesktop information</source>
-        <translation>Информация о AirPodsDesktop</translation>
+        <translation>Информация об AirPodsDesktop</translation>
     </message>
 </context>
 <context>
@@ -250,7 +250,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Щелчок по значку в области уведомлений подключает выбранное устройство вместо открытия главного окна. Двойной щелчок по-прежнему открывает его.</translation>
     </message>
 </context>
 <context>
@@ -292,7 +292,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Visual</source>
-        <translation>Визуальные</translation>
+        <translation>Внешний вид</translation>
     </message>
     <message>
         <source>Display battery on taskbar</source>
@@ -324,7 +324,7 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Features</source>
-        <translation>Особенности</translation>
+        <translation>Функции</translation>
     </message>
     <message>
         <source>Automatic ear detection</source>
@@ -348,15 +348,15 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     </message>
     <message>
         <source>Connect the selected device on a tray icon click</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключать выбранное устройство щелчком по значку в области уведомлений</translation>
     </message>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Устройство</translation>
     </message>
     <message>
         <source>The paired Bluetooth audio device a tray icon click connects.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сопряженное аудиоустройство Bluetooth, к которому выполняется подключение при щелчке по значку в области уведомлений.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_tr_TR.ts
+++ b/Source/Resource/Translation/apd_tr_TR.ts
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr_TR">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>Ayar formatı biraz değişti ve yeniden yapılandırılması gerekiyor.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Merhaba, %1&apos;e hoş geldiniz!
+
+Görünüşe göre bu programı ilk kez kullanıyorsunuz.
+Hadi birlikte bazı ayarları yapalım.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Bu programın sistem başladığında açılmasını ister misiniz?
+
+AirPods&apos;u bu bilgisayarla sık kullanıyorsanız &quot;Evet&quot;e tıklamanız önerilir.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>&quot;Düşük ses gecikmesi&quot; özelliğini etkinleştirmek ister misiniz?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Harika! Her şey hazır!
+
+Keyfini çıkarın.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Beni sistem tepsisinde bulabilirsiniz</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Pil bilgilerini görmek için simgeye tıklayın, ayarları özelleştirmek veya çıkmak için sağ tıklayın.</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Yeni sürümü indir</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Manuel olarak indir</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>İndirme yavaşsa veya başarısız olursa şunları yapabilirsiniz:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Ops, otomatik güncelleme sırasında bir hata oluştu.
+Lütfen yeni sürümü manuel olarak indirip yükleyin.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Değişiklik günlüğü:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Hey! Yeni bir sürüm mevcut!
+
+Mevcut sürüm: %1
+En son sürüm: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>AirPods ile Eşleştir</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Lütfen aşağıdan AirPods cihazınızı seçin.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
+        <translation>Kaan HAS</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Çeviriye Katkıda Bulunanlar:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Üçüncü Taraf Kütüphaneler:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Sol</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Sağ</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Kutu</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>şarj oluyor</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Yeni sürüm mevcut!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Ayarlar</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Hakkında</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Çıkış</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>AirPodsDesktop bilgileri</translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Şimdi güncelle</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Bu sürümü atla</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Sürümü görüntüle</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Daha sonra hatırlat</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Eşleşmiş cihaz bulunamadı.
+Önce Windows Bluetooth Ayarları&apos;ndan AirPods&apos;unuzu eşleştirmeniz gerekir.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Kısa ses çalma sorunlarını düzeltir, ancak pil tüketimini artırabilir.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>AirPods&apos;unuzu çıkardığınızda veya kulağınıza taktığınızda medyayı otomatik olarak duraklatır veya devam ettirir.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Kullanılamıyor</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Bağlantı Kesildi</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>Eşleştirme Bekleniyor</translation>
+    </message>
+</context>
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Seç</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>AirPodsDesktop Ayarları</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Genel</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Log klasörünü aç</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Maksimum Bluetooth kapsama alanı</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>AirPods Bağlantısını Kes</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Sistem başlangıcında çalıştır</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Dil</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Görünüm</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Sistem tepsisi simgesinde pili göster</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Devre Dışı</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>Pil azaldığında</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Her zaman</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Özellikler</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Otomatik kulak algılama</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Düşük ses gecikmesi</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Hakkında</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Açık kaynaklı &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;depo&lt;/span&gt;&lt;/a&gt; ve &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt; altında lisanslanmıştır.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Telif Hakkı © 2021-2022 SpriteOvO. Tüm hakları saklıdır.</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Görev çubuğunda pili göster</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Metin olarak</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Simge olarak</translation>
+    </message>
+</context>
+</TS>

--- a/Source/Resource/Translation/apd_tr_TR.ts
+++ b/Source/Resource/Translation/apd_tr_TR.ts
@@ -114,6 +114,10 @@ En son sürüm: %2%3</translation>
         <source>Third-Party Libraries:</source>
         <translation>Üçüncü Taraf Kütüphaneler:</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>Kayıtlı cihaz (kullanılamıyor)</translation>
+    </message>
 </context>
 <context>
     <name>Gui::TrayIcon</name>
@@ -148,6 +152,46 @@ En son sürüm: %2%3</translation>
     <message>
         <source>Quit</source>
         <translation>Çıkış</translation>
+    </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>Hızlı bağlantı devre dışı.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>Önce Ayarlar&apos;dan bir Bluetooth ses cihazı seçin.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>Seçili cihaz kullanılamıyor. Cihazı açın veya kapsama alanına getirin.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1 zaten bağlı.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>%1 cihazına bağlanılıyor...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 bağlandı.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>%1 bağlantısı zaman aşımına uğradı.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>Windows %1 cihazına bağlanamadı.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>Hızlı bağlantı</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Düşük ses gecikmesi (dip sese neden olabilir)</translation>
     </message>
 </context>
 <context>
@@ -185,10 +229,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Kısa ses çalma sorunlarını düzeltir, ancak pil tüketimini artırabilir.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>AirPods&apos;unuzu çıkardığınızda veya kulağınıza taktığınızda medyayı otomatik olarak duraklatır veya devam ettirir.</translation>
     </message>
@@ -203,6 +243,14 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>Eşleştirme Bekleniyor</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>AirPods&apos;unuz bağlıyken ses cihazını etkin tutar; böylece kısa sesler hemen çalar. Bu, duyulabilir dip sese ve daha fazla pil tüketimine neden olabilir.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>Tepsi simgesine tıklamak ana pencereyi açmak yerine seçili cihaza bağlanır. Çift tıklamak pencereyi açmaya devam eder.</translation>
     </message>
 </context>
 <context>
@@ -297,6 +345,18 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>As icon</source>
         <translation>Simge olarak</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>Tepsi simgesine tıklandığında seçili cihaza bağlan</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Cihaz</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>Tepsi simgesine tıklandığında bağlanılacak eşleştirilmiş Bluetooth ses cihazı.</translation>
     </message>
 </context>
 </TS>

--- a/Source/Resource/Translation/apd_uk_UA.ts
+++ b/Source/Resource/Translation/apd_uk_UA.ts
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk_UA">
+<context>
+    <name>ApdApplication</name>
+    <message>
+        <source>Settings format has changed a bit and needs to be reconfigured.</source>
+        <translation>Формат налаштувань трохи змінився і потребує переналаштування.</translation>
+    </message>
+    <message>
+        <source>Hello, welcome to %1!
+
+This seems to be your first time using this program.
+Let&apos;s configure something together.</source>
+        <translation>Вітаю, ласкаво просимо до %1!
+
+Схоже, це ваш перший досвід використання цієї програми.
+Давайте налаштуємо щось разом.</translation>
+    </message>
+    <message>
+        <source>Do you want this program to launch when the system starts?
+
+If you frequently use AirPods with this computer, it is recommended that you click &quot;Yes&quot;.</source>
+        <translation>Ви хочете, щоб ця програма запустилася, коли система запуститься?
+
+Якщо ви часто користуєтеся AirPods на цьому комп&apos;ютері, рекомендується натиснути &quot;Так&quot;.</translation>
+    </message>
+    <message>
+        <source>Do you want to enable the &quot;low audio latency&quot; feature?
+
+%1</source>
+        <translation>Чи хочете ви увімкнути функцію &quot;низької аудіо затримки&quot;?
+
+%1</translation>
+    </message>
+    <message>
+        <source>Great! Everything is ready!
+
+Enjoy it all.</source>
+        <translation>Чудово! Все готово!
+
+Насолоджуйтесь.</translation>
+    </message>
+    <message>
+        <source>You can find me in the system tray</source>
+        <translation>Мене можна знайти в системному лотку</translation>
+    </message>
+    <message>
+        <source>Click the icon to view battery information, right-click to customize settings or quit.</source>
+        <translation>Натисніть на іконку, щоб переглянути інформацію про батарею, клацніть правою кнопкою миші для налаштування або вийдіть.</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadWindow</name>
+    <message>
+        <source>Download new version</source>
+        <translation>Завантажити нову версію</translation>
+    </message>
+    <message>
+        <source>Download Manually</source>
+        <translation>Завантажити вручну</translation>
+    </message>
+    <message>
+        <source>If the download is slow or fails, you can:</source>
+        <translation>Якщо завантаження повільне або не вдалося, ви можете:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::DownloadWindow</name>
+    <message>
+        <source>Oops, an error occurred during the automatic update.
+Please download and install the new version manually.</source>
+        <translation>Ой, під час автоматичного оновлення сталася помилка.
+Будь ласка, завантажте та встановіть нову версію вручну.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::MainWindow</name>
+    <message>
+        <source>Change log:</source>
+        <translation>Журнал змін:</translation>
+    </message>
+    <message>
+        <source>Hey! I found a new version available!
+
+Current version: %1
+Latest version: %2%3</source>
+        <translation>Салют! Я знайшов нову версію!
+
+Поточна версія: %1
+Остання версія: %2%3</translation>
+    </message>
+    <message>
+        <source>Bind to AirPods</source>
+        <translation>Прив&apos;язати до AirPods</translation>
+    </message>
+    <message>
+        <source>Please select your AirPods device below.</source>
+        <translation>Будь ласка, оберіть свій пристрій AirPods нижче.</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::SettingsWindow</name>
+    <message>
+        <source>|</source>
+        <extracomment>To credit translators, you can leave your name here if you wish. (Sorted by time added, separated by &quot;|&quot; character, only single &quot;|&quot; for empty)</extracomment>
+        <translation>andryua</translation>
+    </message>
+    <message>
+        <source>Translation Contributors:</source>
+        <translation>Автори перекладу:</translation>
+    </message>
+    <message>
+        <source>Third-Party Libraries:</source>
+        <translation>Сторонні бібліотеки:</translation>
+    </message>
+</context>
+<context>
+    <name>Gui::TrayIcon</name>
+    <message>
+        <source>Left</source>
+        <translation>Лівий</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Правий</translation>
+    </message>
+    <message>
+        <source>Case</source>
+        <translation>Футляр</translation>
+    </message>
+    <message>
+        <source>charging</source>
+        <translation>заряджати</translation>
+    </message>
+    <message>
+        <source>New version available!</source>
+        <translation>Доступна нова версія!</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Про програму</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Вийти</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>AirPodsDesktop information</source>
+        <translation>Інформація про AirPodsDesktop</translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <source>Update now</source>
+        <translation>Оновити зараз</translation>
+    </message>
+    <message>
+        <source>Skip this version</source>
+        <translation>Пропустити цю версію</translation>
+    </message>
+    <message>
+        <source>View release</source>
+        <translation>Переглянути реліз</translation>
+    </message>
+    <message>
+        <source>Remind me later</source>
+        <translation>Нагадати мені пізніше</translation>
+    </message>
+    <message>
+        <source>No paired device found.
+You need to pair your AirPods in Windows Bluetooth Settings first.</source>
+        <translation>Спарений пристрій не знайдено.
+Спочатку потрібно підключити AirPods у налаштуваннях Bluetooth Windows.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
+        <translation>Це вирішує проблеми з коротким відтворенням аудіо, але може збільшити споживання батареї.</translation>
+    </message>
+    <message>
+        <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
+        <translation>Автоматично призупиняє або відновлює медіа, коли AirPods виймають або ставлять у вуха.</translation>
+    </message>
+    <message>
+        <source>Unavailable</source>
+        <translation>Недоступно</translation>
+    </message>
+    <message>
+        <source>Disconnected</source>
+        <translation>Відключено</translation>
+    </message>
+    <message>
+        <source>Waiting for Binding</source>
+        <translation>Очікування на зв&apos;язування</translation>
+    </message>
+</context>
+<context>
+    <name>SelectWindow</name>
+    <message>
+        <source>Select</source>
+        <translation>Виберіть</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>AirPodsDesktop Settings</source>
+        <translation>Налаштування AirPodsDesktop</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Загальні</translation>
+    </message>
+    <message>
+        <source>Open logs directory</source>
+        <translation>Відкрити каталог журналів</translation>
+    </message>
+    <message>
+        <source>Bluetooth maximum receiving range</source>
+        <translation>Максимальний радіус прийому Bluetooth</translation>
+    </message>
+    <message>
+        <source>Unbind AirPods</source>
+        <translation>Відв&apos;язати AirPods</translation>
+    </message>
+    <message>
+        <source>Launch when system starts</source>
+        <translation>Запуск при старті системи</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Мова</translation>
+    </message>
+    <message>
+        <source>Visual</source>
+        <translation>Візуальні</translation>
+    </message>
+    <message>
+        <source>Display battery on taskbar</source>
+        <translation>Відобразити батарею на панелі завдань</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>Відключити</translation>
+    </message>
+    <message>
+        <source>When low battery</source>
+        <translation>Коли заряд батареї низький</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Завжди</translation>
+    </message>
+    <message>
+        <source>As text</source>
+        <translation>Як текст</translation>
+    </message>
+    <message>
+        <source>As icon</source>
+        <translation>Як іконка</translation>
+    </message>
+    <message>
+        <source>Display battery on tray icon</source>
+        <translation>Відобразити батарею на іконці лотка</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Особливості</translation>
+    </message>
+    <message>
+        <source>Automatic ear detection</source>
+        <translation>Автоматичне виявлення вуха</translation>
+    </message>
+    <message>
+        <source>Low audio latency</source>
+        <translation>Низька затримка аудіо</translation>
+    </message>
+    <message>
+        <source>About</source>
+        <translation>Про програму</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Open source &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Відкритий код &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;repository&lt;/span&gt;&lt;/a&gt; and licensed under &lt;a href=&quot;https://github.com/SpriteOvO/AirPodsDesktop/blob/main/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;GPLv3&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
+        <translation>Авторські права © 2021-2022 SpriteOvO. Всі права захищені.</translation>
+    </message>
+</context>
+</TS>

--- a/Source/Resource/Translation/apd_uk_UA.ts
+++ b/Source/Resource/Translation/apd_uk_UA.ts
@@ -114,6 +114,10 @@ Latest version: %2%3</source>
         <source>Third-Party Libraries:</source>
         <translation>Сторонні бібліотеки:</translation>
     </message>
+    <message>
+        <source>Saved device (not available)</source>
+        <translation>Збережений пристрій (недоступний)</translation>
+    </message>
 </context>
 <context>
     <name>Gui::TrayIcon</name>
@@ -148,6 +152,46 @@ Latest version: %2%3</source>
     <message>
         <source>Quit</source>
         <translation>Вийти</translation>
+    </message>
+    <message>
+        <source>Quick connection is disabled.</source>
+        <translation>Швидке підключення вимкнено.</translation>
+    </message>
+    <message>
+        <source>Choose a Bluetooth audio device in Settings first.</source>
+        <translation>Спочатку виберіть аудіопристрій Bluetooth у налаштуваннях.</translation>
+    </message>
+    <message>
+        <source>The selected device is not available. Turn it on or bring it into range.</source>
+        <translation>Вибраний пристрій недоступний. Увімкніть його або перемістіть у зону дії.</translation>
+    </message>
+    <message>
+        <source>%1 is already connected.</source>
+        <translation>%1 уже підключено.</translation>
+    </message>
+    <message>
+        <source>Connecting to %1...</source>
+        <translation>Підключення до %1...</translation>
+    </message>
+    <message>
+        <source>%1 connected.</source>
+        <translation>%1 підключено.</translation>
+    </message>
+    <message>
+        <source>Connection to %1 timed out.</source>
+        <translation>Час очікування підключення до %1 минув.</translation>
+    </message>
+    <message>
+        <source>Windows could not connect to %1.</source>
+        <translation>Windows не вдалося підключитися до %1.</translation>
+    </message>
+    <message>
+        <source>Quick connect</source>
+        <translation>Швидке підключення</translation>
+    </message>
+    <message>
+        <source>Low audio latency (may cause hiss)</source>
+        <translation>Низька затримка звуку (може спричинити шипіння)</translation>
     </message>
 </context>
 <context>
@@ -185,10 +229,6 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>It fixes short audio playback problems, but may increase battery consumption.</source>
-        <translation>Це вирішує проблеми з коротким відтворенням аудіо, але може збільшити споживання батареї.</translation>
-    </message>
-    <message>
         <source>It automatically pauses or resumes media when your AirPods are taken out or put in your ears.</source>
         <translation>Автоматично призупиняє або відновлює медіа, коли AirPods виймають або ставлять у вуха.</translation>
     </message>
@@ -203,6 +243,14 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Waiting for Binding</source>
         <translation>Очікування на зв&apos;язування</translation>
+    </message>
+    <message>
+        <source>Keeps the audio device awake while your AirPods are connected so short sounds start immediately. This may produce audible hiss and use more battery.</source>
+        <translation>Підтримує аудіопристрій активним, поки AirPods підключені, щоб короткі звуки відтворювалися негайно. Це може спричинити чутне шипіння та збільшити споживання заряду.</translation>
+    </message>
+    <message>
+        <source>A click on the tray icon connects the selected device instead of opening the main window. Double-click still opens it.</source>
+        <translation>Клацання піктограми в області сповіщень підключає вибраний пристрій замість відкриття головного вікна. Подвійне клацання, як і раніше, відкриває його.</translation>
     </message>
 </context>
 <context>
@@ -297,6 +345,18 @@ You need to pair your AirPods in Windows Bluetooth Settings first.</source>
     <message>
         <source>Copyright © 2021-2022 SpriteOvO. All rights reserved.</source>
         <translation>Авторські права © 2021-2022 SpriteOvO. Всі права захищені.</translation>
+    </message>
+    <message>
+        <source>Connect the selected device on a tray icon click</source>
+        <translation>Підключати вибраний пристрій клацанням піктограми в області сповіщень</translation>
+    </message>
+    <message>
+        <source>Device</source>
+        <translation>Пристрій</translation>
+    </message>
+    <message>
+        <source>The paired Bluetooth audio device a tray icon click connects.</source>
+        <translation>Спарений аудіопристрій Bluetooth, до якого виконується підключення після клацання піктограми в області сповіщень.</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

- consolidate the community translations from #202, #182, #179, #174, #172, and #129
- add Bulgarian, Italian, European Portuguese, Turkish, and Ukrainian locales, plus the Korean wording refinement
- synchronize all six contributed catalogs with the current 74-string source catalog
- translate the 16 newer quick-connect strings in every contributed locale
- complete and polish the German, French, Japanese, Russian, and Brazilian Portuguese catalogs
- preserve all eight original commits and their author metadata so each translator remains credited as a contributor

## Attribution

- #202 — Italian by @RyoSaebaChan
- #182 — Ukrainian by @andryua
- #179 — Korean refinement by @Resi-le
- #174 — Turkish by @haskaan
- #172 — Bulgarian by @m-chavalinov
- #129 — European Portuguese by @kikosgc

This PR supersedes the six source PRs while retaining their individual commit history.

## Verification

- parsed every `.ts` file as XML
- verified all 13 locales have 74 messages, 0 unfinished or empty translations, and 0 placeholder mismatches
- compiled every changed catalog with Qt `lrelease`: 74 finished, 0 unfinished
- `git diff --check` passes
- attempted a Visual Studio 2019 Win32 `RelWithDebInfo` configure with tests enabled; generation is blocked on this machine because the existing project dependencies `Boost.PFR` and `Boost.Stacktrace` are not installed, so the full C++ build and `ctest` could not run locally
