### PR TITLE
feat: support AirPods Max USB-C

### DIFF
--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -28,6 +28,15 @@
 
 namespace Core::AirPods {
 
+QString Details::ResolveDisplayName(QString deviceName, Model model)
+{
+    deviceName.remove(" - Find My");
+
+    const bool isDefaultUsbCMaxName =
+        model == Model::AirPods_Max_USB_C && deviceName == "AirPods Max";
+    return deviceName.isEmpty() || isDefaultUsbCMaxName ? Helper::ToString(model) : deviceName;
+}
+
 Manager::Manager(QObject *parent) : QObject{parent}
 {
     _stateMgr.SetOnDiscardState([this] {
@@ -213,10 +222,7 @@ void Manager::OnStateChanged(Details::StateManager::UpdateEvent updateEvent)
     const auto &oldState = updateEvent.oldState;
     auto &newState = updateEvent.newState;
 
-    // AirPods Max 2 Bluetooth name is "AirPods Max" same as original; use model string to distinguish.
-    bool useModelName = _deviceName.isEmpty() || newState.model == Model::AirPods_Max_2;
-    newState.displayName =
-        useModelName ? Helper::ToString(newState.model) : _deviceName.remove(" - Find My");
+    newState.displayName = Details::ResolveDisplayName(_deviceName, newState.model);
 
     emit StateUpdated(newState);
 

--- a/Source/Core/AirPods.cpp
+++ b/Source/Core/AirPods.cpp
@@ -213,8 +213,10 @@ void Manager::OnStateChanged(Details::StateManager::UpdateEvent updateEvent)
     const auto &oldState = updateEvent.oldState;
     auto &newState = updateEvent.newState;
 
+    // AirPods Max 2 Bluetooth name is "AirPods Max" same as original; use model string to distinguish.
+    bool useModelName = _deviceName.isEmpty() || newState.model == Model::AirPods_Max_2;
     newState.displayName =
-        _deviceName.isEmpty() ? Helper::ToString(newState.model) : _deviceName.remove(" - Find My");
+        useModelName ? Helper::ToString(newState.model) : _deviceName.remove(" - Find My");
 
     emit StateUpdated(newState);
 

--- a/Source/Core/AirPods.h
+++ b/Source/Core/AirPods.h
@@ -83,6 +83,8 @@ struct State {
 
 namespace Details {
 
+QString ResolveDisplayName(QString deviceName, Model model);
+
 class Advertisement
 {
 public:

--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -62,6 +62,8 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
         return Core::AirPods::Model::AirPods_Pro_3;
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
+    case 0x201F:
+        return Core::AirPods::Model::AirPods_Max_2;
         // case 0x2003:
         //    return Core::AirPods::Model::Powerbeats_3;
         // case 0x2005:

--- a/Source/Core/AppleCP.cpp
+++ b/Source/Core/AppleCP.cpp
@@ -63,7 +63,7 @@ Core::AirPods::Model AirPods::GetModel(uint16_t modelId)
     case 0x200A:
         return Core::AirPods::Model::AirPods_Max;
     case 0x201F:
-        return Core::AirPods::Model::AirPods_Max_2;
+        return Core::AirPods::Model::AirPods_Max_USB_C;
         // case 0x2003:
         //    return Core::AirPods::Model::Powerbeats_3;
         // case 0x2005:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -74,6 +74,7 @@ enum class Model : uint32_t {
     AirPods_Pro_2_USB_C,
     AirPods_Pro_3,
     AirPods_Max,
+    AirPods_Max_2,
     Powerbeats_3,
     Beats_X,
     Beats_Solo3,
@@ -110,6 +111,8 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro 3";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
+    case Core::AirPods::Model::AirPods_Max_2:
+        return "AirPods Max (2024)";
     case Core::AirPods::Model::Powerbeats_3:
         return "Powerbeats 3";
     case Core::AirPods::Model::Beats_X:

--- a/Source/Core/Base.h
+++ b/Source/Core/Base.h
@@ -74,7 +74,7 @@ enum class Model : uint32_t {
     AirPods_Pro_2_USB_C,
     AirPods_Pro_3,
     AirPods_Max,
-    AirPods_Max_2,
+    AirPods_Max_USB_C,
     Powerbeats_3,
     Beats_X,
     Beats_Solo3,
@@ -111,8 +111,8 @@ inline QString Helper::ToString<Core::AirPods::Model>(const Core::AirPods::Model
         return "AirPods Pro 3";
     case Core::AirPods::Model::AirPods_Max:
         return "AirPods Max";
-    case Core::AirPods::Model::AirPods_Max_2:
-        return "AirPods Max (2024)";
+    case Core::AirPods::Model::AirPods_Max_USB_C:
+        return "AirPods Max (USB-C)";
     case Core::AirPods::Model::Powerbeats_3:
         return "Powerbeats 3";
     case Core::AirPods::Model::Beats_X:

--- a/Source/Gui/MainWindowPresentation.cpp
+++ b/Source/Gui/MainWindowPresentation.cpp
@@ -122,7 +122,7 @@ AnimationPresentation GetAnimationPresentation(Core::AirPods::Model model)
     case Model::AirPods_Pro_3:
         return {"qrc:/Resource/Video/AirPods_Pro_3.avi", {900, 450}};
     case Model::AirPods_Max:
-    case Model::AirPods_Max_2:
+    case Model::AirPods_Max_USB_C:
         return {"qrc:/Resource/Video/AirPods_Max.avi", {600, 650}};
     case Model::Beats_Fit_Pro:
         return {"qrc:/Resource/Video/Beats_Fit_Pro.avi", {900, 450}};

--- a/Source/Gui/MainWindowPresentation.cpp
+++ b/Source/Gui/MainWindowPresentation.cpp
@@ -122,6 +122,7 @@ AnimationPresentation GetAnimationPresentation(Core::AirPods::Model model)
     case Model::AirPods_Pro_3:
         return {"qrc:/Resource/Video/AirPods_Pro_3.avi", {900, 450}};
     case Model::AirPods_Max:
+    case Model::AirPods_Max_2:
         return {"qrc:/Resource/Video/AirPods_Max.avi", {600, 650}};
     case Model::Beats_Fit_Pro:
         return {"qrc:/Resource/Video/Beats_Fit_Pro.avi", {900, 450}};

--- a/Tests/AirPodsDomainTests.cpp
+++ b/Tests/AirPodsDomainTests.cpp
@@ -107,6 +107,8 @@ class AirPodsDomainTests : public QObject
 
 private Q_SLOTS:
     void RejectsMalformedPackets();
+    void RecognizesAirPodsMaxUsbC();
+    void ResolvesAirPodsMaxUsbCDisplayName();
     void ParsesAdvertisementState();
     void FiltersDuplicateAndWeakAdvertisements();
     void MergesAdvertisementsFromBothSides();
@@ -142,6 +144,26 @@ void AirPodsDomainTests::RejectsMalformedPackets()
     packet = MakePacket(0x2014, Side::Left, 8, 7, 5);
     packet[1] = 24;
     QVERIFY(!Core::AppleCP::AirPods::IsValid(packet));
+}
+
+void AirPodsDomainTests::RecognizesAirPodsMaxUsbC()
+{
+    QCOMPARE(Core::AppleCP::AirPods::GetModel(0x201F), Model::AirPods_Max_USB_C);
+    QCOMPARE(Helper::ToString(Model::AirPods_Max_USB_C), QString{"AirPods Max (USB-C)"});
+}
+
+void AirPodsDomainTests::ResolvesAirPodsMaxUsbCDisplayName()
+{
+    QCOMPARE(
+        Core::AirPods::Details::ResolveDisplayName("AirPods Max", Model::AirPods_Max_USB_C),
+        QString{"AirPods Max (USB-C)"});
+    QCOMPARE(
+        Core::AirPods::Details::ResolveDisplayName(
+            "Studio AirPods Max - Find My", Model::AirPods_Max_USB_C),
+        QString{"Studio AirPods Max"});
+    QCOMPARE(
+        Core::AirPods::Details::ResolveDisplayName("AirPods Max", Model::AirPods_Max),
+        QString{"AirPods Max"});
 }
 
 void AirPodsDomainTests::BuildsLowBandwidthSilenceFormats()
@@ -535,6 +557,10 @@ void AirPodsDomainTests::MapsMainWindowAnimationResources()
     const auto pro = Gui::GetAnimationPresentation(Core::AirPods::Model::AirPods_Pro_2_USB_C);
     QCOMPARE(pro.resource, QString{"qrc:/Resource/Video/AirPods_Pro_2.avi"});
     QCOMPARE(pro.sourceSize, QSize(900, 450));
+
+    const auto maxUsbC = Gui::GetAnimationPresentation(Core::AirPods::Model::AirPods_Max_USB_C);
+    QCOMPARE(maxUsbC.resource, QString{"qrc:/Resource/Video/AirPods_Max.avi"});
+    QCOMPARE(maxUsbC.sourceSize, QSize(600, 650));
 
     const auto fallback = Gui::GetAnimationPresentation(Core::AirPods::Model::Unknown);
     QCOMPARE(fallback.resource, QString{"qrc:/Resource/Video/AirPods_1.avi"});


### PR DESCRIPTION
## Summary

- recognize AirPods Max 1 (USB-C) product ID `0x201F` as a distinct supported model
- preserve personalized Bluetooth names while distinguishing the default AirPods Max name
- reuse the existing AirPods Max animation and add regression coverage for model, naming, and presentation mappings

## Validation

- `cmake --build Build\Win32 --config RelWithDebInfo --parallel`
- `ctest --test-dir Build\Win32 -C RelWithDebInfo --output-on-failure` (2/2 passed)
- `git diff --check`

## Context

Supersedes #197 and builds on @chrolicious's original implementation. This version is rebased on the latest `main`, uses the correct first-generation USB-C model identity, preserves custom device names, and includes tests.