### PR TITLE
fix: make taskbar status geometry DPI-aware

### DIFF
--- a/Source/Gui/TaskbarGeometry.h
+++ b/Source/Gui/TaskbarGeometry.h
@@ -1,0 +1,88 @@
+//
+// AirPodsDesktop - AirPods Desktop User Experience Enhancement Program.
+// Copyright (C) 2021-2022 SpriteOvO
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+#include <QRect>
+#include <QSize>
+
+namespace Gui::TaskbarGeometry {
+
+struct Layout {
+    QRect statusLogical;
+    QRect taskButtonsNative;
+};
+
+constexpr inline int kDefaultDpi = 96;
+
+inline int NativeToLogical(int value, int dpi)
+{
+    const auto effectiveDpi = dpi > 0 ? dpi : kDefaultDpi;
+    return static_cast<int>(std::lround(static_cast<double>(value) * kDefaultDpi / effectiveDpi));
+}
+
+inline int LogicalToNative(int value, int dpi)
+{
+    const auto effectiveDpi = dpi > 0 ? dpi : kDefaultDpi;
+    return static_cast<int>(std::lround(static_cast<double>(value) * effectiveDpi / kDefaultDpi));
+}
+
+inline Layout CalculateLayout(
+    const QSize &rebarNativeSize, const QRect &taskButtonsNative, int dpi, bool horizontal,
+    const QSize &statusLogicalSize = {60, 40})
+{
+    auto adjustedTaskButtons = taskButtonsNative;
+    QRect status;
+
+    if (horizontal) {
+        const auto statusNativeWidth = LogicalToNative(statusLogicalSize.width(), dpi);
+        adjustedTaskButtons.setWidth(
+            std::max(0, rebarNativeSize.width() - statusNativeWidth - taskButtonsNative.left()));
+        status = {
+            NativeToLogical(rebarNativeSize.width(), dpi) - statusLogicalSize.width(), 0,
+            statusLogicalSize.width(), NativeToLogical(taskButtonsNative.height(), dpi)};
+    }
+    else {
+        const auto statusNativeHeight = LogicalToNative(statusLogicalSize.height(), dpi);
+        adjustedTaskButtons.setHeight(
+            std::max(0, rebarNativeSize.height() - statusNativeHeight - taskButtonsNative.top()));
+        status = {
+            0, NativeToLogical(rebarNativeSize.height(), dpi) - statusLogicalSize.height(),
+            NativeToLogical(taskButtonsNative.width(), dpi), statusLogicalSize.height()};
+    }
+
+    return {.statusLogical = status, .taskButtonsNative = adjustedTaskButtons};
+}
+
+inline QRect
+RestoreTaskButtons(const QSize &rebarNativeSize, const QRect &taskButtonsNative, bool horizontal)
+{
+    auto restored = taskButtonsNative;
+    if (horizontal) {
+        restored.setWidth(std::max(0, rebarNativeSize.width() - taskButtonsNative.left()));
+    }
+    else {
+        restored.setHeight(std::max(0, rebarNativeSize.height() - taskButtonsNative.top()));
+    }
+    return restored;
+}
+
+} // namespace Gui::TaskbarGeometry

--- a/Source/Gui/TaskbarStatus.cpp
+++ b/Source/Gui/TaskbarStatus.cpp
@@ -17,6 +17,7 @@
 //
 
 #include "TaskbarStatus.h"
+#include "TaskbarGeometry.h"
 
 #include <QWindow>
 #include <QApplication>
@@ -246,71 +247,32 @@ void TaskbarStatus::UpdatePos(const TaskBarInfo &info, bool enable)
 {
     LOG(Trace, "The taskbar is '{}'", info.isHorizontal ? "horizontal" : "vertical");
 
-    const auto &rectMSTaskSwWClass = info.rectMSTaskSwWClass;
     const auto &rectMSTaskSwWClassForParent = info.rectMSTaskSwWClassForParent;
     const auto &rectReBarWindow32 = info.rectReBarWindow32;
+    const auto dpi = static_cast<int>(GetDpiForWindow(info.hReBarWindow32));
+    const auto layout = TaskbarGeometry::CalculateLayout(
+        rectReBarWindow32.size(), rectMSTaskSwWClassForParent, dpi, info.isHorizontal,
+        QSize{kFixedWidth, kFixedHeight});
 
     if (enable) {
         if (!_isWin11OrGreater) {
-            if (info.isHorizontal) {
-                // Avoid causing multiple moves
-                auto newWidth = rectReBarWindow32.right() - kFixedWidth - rectMSTaskSwWClass.left();
-
-                MoveWindow(
-                    info.hMSTaskSwWClass, rectMSTaskSwWClassForParent.left(),
-                    rectMSTaskSwWClassForParent.top(), newWidth,
-                    rectMSTaskSwWClassForParent.height(), true);
-
-                move(rectReBarWindow32.width() - kFixedWidth, 0);
-            }
-            else {
-                // Same as above
-                auto newHeight =
-                    rectReBarWindow32.bottom() - kFixedHeight - rectMSTaskSwWClass.top();
-
-                MoveWindow(
-                    info.hMSTaskSwWClass, rectMSTaskSwWClassForParent.left(),
-                    rectMSTaskSwWClassForParent.top(), rectMSTaskSwWClassForParent.width(),
-                    newHeight, true);
-
-                move(0, rectReBarWindow32.height() - kFixedHeight);
-            }
-        }
-        else {
-            if (info.isHorizontal) {
-                move(rectReBarWindow32.width() - kFixedWidth, 0);
-            }
-            else {
-                // Currently Windows 11 does not support vertical taskbar, so we were unable to test
-                // it.
-                move(0, rectReBarWindow32.height() - kFixedHeight);
-            }
+            const auto &taskButtons = layout.taskButtonsNative;
+            MoveWindow(
+                info.hMSTaskSwWClass, taskButtons.left(), taskButtons.top(), taskButtons.width(),
+                taskButtons.height(), true);
         }
 
-        if (info.isHorizontal) {
-            _cachedLength = rectReBarWindow32.width();
-            setFixedSize(kFixedWidth, info.rectMSTaskSwWClass.height());
-        }
-        else {
-            _cachedLength = rectReBarWindow32.height();
-            setFixedSize(info.rectMSTaskSwWClass.width(), kFixedHeight);
-        }
+        move(layout.statusLogical.topLeft());
+        setFixedSize(layout.statusLogical.size());
+        _cachedLength = info.isHorizontal ? rectReBarWindow32.width() : rectReBarWindow32.height();
     }
     else {
         if (!_isWin11OrGreater) {
-            if (info.isHorizontal) {
-                MoveWindow(
-                    info.hMSTaskSwWClass, rectMSTaskSwWClassForParent.left(),
-                    rectMSTaskSwWClassForParent.top(),
-                    rectReBarWindow32.right() - rectMSTaskSwWClass.left(),
-                    rectMSTaskSwWClass.height(), true);
-            }
-            else {
-                MoveWindow(
-                    info.hMSTaskSwWClass, rectMSTaskSwWClassForParent.left(),
-                    rectMSTaskSwWClassForParent.top(), rectMSTaskSwWClass.width(),
-                    rectReBarWindow32.bottom() - rectMSTaskSwWClass.top(), true);
-            }
+            const auto restored = TaskbarGeometry::RestoreTaskButtons(
+                rectReBarWindow32.size(), rectMSTaskSwWClassForParent, info.isHorizontal);
+            MoveWindow(
+                info.hMSTaskSwWClass, restored.left(), restored.top(), restored.width(),
+                restored.height(), true);
         }
     }
 }

--- a/Tests/AirPodsDomainTests.cpp
+++ b/Tests/AirPodsDomainTests.cpp
@@ -13,6 +13,7 @@
 #include "Source/Core/SettingsRepository.h"
 #include "Source/Core/Update.h"
 #include "Source/Gui/MainWindowPresentation.h"
+#include "Source/Gui/TaskbarGeometry.h"
 
 namespace {
 
@@ -128,6 +129,7 @@ private Q_SLOTS:
     void PresentsMainWindowDeviceState();
     void PresentsMainWindowCaseBattery();
     void MapsMainWindowAnimationResources();
+    void ConvertsTaskbarGeometryAcrossDpiBoundaries();
 };
 
 void AirPodsDomainTests::RejectsMalformedPackets()
@@ -583,6 +585,28 @@ void AirPodsDomainTests::MapsMainWindowAnimationResources()
             QFile::exists(QString{APD_SOURCE_DIR} + "/Source/Resource/" + entry),
             qPrintable(QString{"animation file missing: %1"}.arg(entry)));
     }
+}
+
+void AirPodsDomainTests::ConvertsTaskbarGeometryAcrossDpiBoundaries()
+{
+    // Reproduces issue #217: one 2560x1440 monitor at 125% display scaling. Win32 reports
+    // physical pixels, while QWidget geometry is expressed in device-independent pixels.
+    const auto layout =
+        Gui::TaskbarGeometry::CalculateLayout(QSize{2560, 50}, QRect{160, 0, 2325, 50}, 120, true);
+
+    QCOMPARE(layout.statusLogical, QRect(1988, 0, 60, 40));
+    QCOMPARE(layout.taskButtonsNative, QRect(160, 0, 2325, 50));
+
+    QCOMPARE(Gui::TaskbarGeometry::LogicalToNative(layout.statusLogical.right() + 1, 120), 2560);
+
+    const auto restored =
+        Gui::TaskbarGeometry::RestoreTaskButtons(QSize{2560, 50}, layout.taskButtonsNative, true);
+    QCOMPARE(restored, QRect(160, 0, 2400, 50));
+
+    const auto vertical =
+        Gui::TaskbarGeometry::CalculateLayout(QSize{50, 1440}, QRect{0, 120, 50, 1270}, 120, false);
+    QCOMPARE(vertical.statusLogical, QRect(0, 1112, 40, 40));
+    QCOMPARE(vertical.taskButtonsNative, QRect(0, 120, 50, 1270));
 }
 
 QTEST_GUILESS_MAIN(AirPodsDomainTests)


### PR DESCRIPTION
## Summary

- convert native Win32 taskbar measurements to Qt logical coordinates before positioning the embedded battery window
- keep Windows task-button resizing and restoration in native pixels
- add a regression test reproducing a 2560×1440 display at 125% scaling

## Root cause

AirPodsDesktop v0.5.x enables Per-Monitor V2 DPI awareness, but `TaskbarStatus` passed physical pixel values from `GetWindowRect` and `MapWindowPoints` directly to Qt's logical-coordinate `move` and `setFixedSize` APIs. At the 125% scaling reported in #217, the status window was positioned at 2500 logical pixels instead of 1988, placing it beyond the native 2560-pixel taskbar boundary.

The fix keeps Win32 geometry in native pixels and converts only at the Qt boundary using the DPI reported by the taskbar window.

## Validation

- Added a red/green regression test for the reporter's 2560×1440, 125% (120 DPI) environment
- Verified horizontal placement, native task-button reservation, disable-time restoration, and vertical taskbar geometry
- Built the complete Win32 RelWithDebInfo application successfully with Qt 5.15.2
- `AirPodsDomainTests`: passed
- `QuickConnectTests`: passed

Fixes #217