### PR TITLE
fix: restore compatible low-latency playback

### DIFF
--- a/Source/Core/LowAudioLatency.cpp
+++ b/Source/Core/LowAudioLatency.cpp
@@ -18,179 +18,12 @@
 
 #include "LowAudioLatency.h"
 
-#include <algorithm>
-#include <array>
-#include <cstring>
-#include <vector>
-
 #include <QAudioDeviceInfo>
-#include <QIODevice>
+#include <QUrl>
 
 #include "../Logger.h"
 
 namespace Core::LowAudioLatency {
-
-namespace Details {
-
-std::vector<QAudioFormat> BuildSilenceFormatCandidates(
-    const QList<int> &sampleSizes, const QList<QAudioFormat::SampleType> &sampleTypes,
-    const QList<QAudioFormat::Endian> &byteOrders)
-{
-    auto orderedSampleSizes = sampleSizes;
-    std::sort(orderedSampleSizes.begin(), orderedSampleSizes.end());
-    orderedSampleSizes.erase(
-        std::unique(orderedSampleSizes.begin(), orderedSampleSizes.end()),
-        orderedSampleSizes.end());
-
-    constexpr std::array kSampleTypePreference{
-        QAudioFormat::SignedInt,
-        QAudioFormat::UnSignedInt,
-        QAudioFormat::Float,
-    };
-    constexpr std::array kByteOrderPreference{
-        QAudioFormat::LittleEndian,
-        QAudioFormat::BigEndian,
-    };
-
-    std::vector<QAudioFormat> candidates;
-    for (const auto sampleSize : orderedSampleSizes) {
-        for (const auto sampleType : kSampleTypePreference) {
-            if (!sampleTypes.contains(sampleType)) {
-                continue;
-            }
-            for (const auto byteOrder : kByteOrderPreference) {
-                if (!byteOrders.contains(byteOrder)) {
-                    continue;
-                }
-
-                QAudioFormat format;
-                format.setSampleRate(8000);
-                format.setChannelCount(1);
-                format.setSampleSize(sampleSize);
-                format.setCodec("audio/pcm");
-                format.setByteOrder(byteOrder);
-                format.setSampleType(sampleType);
-                candidates.push_back(format);
-            }
-        }
-    }
-    return candidates;
-}
-
-std::vector<uint8_t> CreateSilentFrame(const QAudioFormat &format)
-{
-    const auto bitsPerSample = std::max(1, format.sampleSize());
-    const auto bytesPerSample = std::max(1, (bitsPerSample + 7) / 8);
-    const auto channelCount = std::max(1, format.channelCount());
-    std::vector<uint8_t> frame(static_cast<size_t>(bytesPerSample * channelCount), 0);
-
-    if (format.sampleType() != QAudioFormat::UnSignedInt) {
-        return frame;
-    }
-
-    const auto midpointBit = bitsPerSample - 1;
-    const auto byteFromLeastSignificant = midpointBit / 8;
-    const auto midpointMask = static_cast<uint8_t>(1u << (midpointBit % 8));
-    const auto midpointByte = format.byteOrder() == QAudioFormat::LittleEndian
-                                  ? byteFromLeastSignificant
-                                  : bytesPerSample - byteFromLeastSignificant - 1;
-    for (auto channel = 0; channel < channelCount; ++channel) {
-        frame[static_cast<size_t>(channel * bytesPerSample + midpointByte)] = midpointMask;
-    }
-    return frame;
-}
-
-} // namespace Details
-
-namespace {
-
-QAudioFormat CreateSilenceFormat(const QAudioDeviceInfo &device)
-{
-    const auto candidates = Details::BuildSilenceFormatCandidates(
-        device.supportedSampleSizes(), device.supportedSampleTypes(), device.supportedByteOrders());
-    for (const auto &candidate : candidates) {
-        if (device.isFormatSupported(candidate)) {
-            return candidate;
-        }
-    }
-
-    QAudioFormat fallback;
-    fallback.setSampleRate(8000);
-    fallback.setChannelCount(1);
-    fallback.setSampleSize(16);
-    fallback.setCodec("audio/pcm");
-    fallback.setByteOrder(QAudioFormat::LittleEndian);
-    fallback.setSampleType(QAudioFormat::SignedInt);
-    return device.nearestFormat(fallback);
-}
-
-} // namespace
-
-class SilenceDevice final : public QIODevice
-{
-public:
-    explicit SilenceDevice(const QAudioFormat &format, QObject *parent = nullptr)
-        : QIODevice{parent}, _silentFrame{Details::CreateSilentFrame(format)}
-    {
-        _zeroFilled = std::all_of(
-            _silentFrame.cbegin(), _silentFrame.cend(), [](const auto byte) { return byte == 0; });
-    }
-
-    void Start()
-    {
-        open(QIODevice::ReadOnly);
-    }
-
-    void Stop()
-    {
-        close();
-    }
-
-    bool isSequential() const override
-    {
-        return true;
-    }
-
-    qint64 bytesAvailable() const override
-    {
-        return kBufferHint + QIODevice::bytesAvailable();
-    }
-
-protected:
-    qint64 readData(char *data, qint64 maxSize) override
-    {
-        if (maxSize <= 0) {
-            return 0;
-        }
-
-        if (_zeroFilled) {
-            std::memset(data, 0, static_cast<size_t>(maxSize));
-            return maxSize;
-        }
-
-        auto remaining = static_cast<size_t>(maxSize);
-        auto *output = reinterpret_cast<uint8_t *>(data);
-        while (remaining > 0) {
-            const auto chunk = std::min(remaining, _silentFrame.size() - _frameOffset);
-            std::memcpy(output, _silentFrame.data() + _frameOffset, chunk);
-            output += chunk;
-            remaining -= chunk;
-            _frameOffset = (_frameOffset + chunk) % _silentFrame.size();
-        }
-        return maxSize;
-    }
-
-    qint64 writeData(const char *, qint64) override
-    {
-        return -1;
-    }
-
-private:
-    constexpr static inline qint64 kBufferHint = 4096;
-    std::vector<uint8_t> _silentFrame;
-    size_t _frameOffset{0};
-    bool _zeroFilled{true};
-};
 
 Controller::Controller(QObject *parent) : QObject{parent}
 {
@@ -205,72 +38,60 @@ Controller::Controller(QObject *parent) : QObject{parent}
         }
         StartWhenReady();
     });
-
-    _deviceCheckTimer.setInterval(kDeviceCheckInterval);
-    _deviceCheckTimer.callOnTimeout([this] { CheckOutputDevice(); });
 }
 
 Controller::~Controller()
 {
-    Stop();
+    _initTimer.stop();
+    ResetAudio();
 }
 
 bool Controller::Initialize()
 {
     // issue #20
     //
-    // Constructing audio output when no audio output device is enabled will cause repeated
-    // playback errors and is unrecoverable until the device list changes.
-    const auto devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
-    if (devices.empty()) {
+    // Constructing `QMediaPlayer` when no audio output device is enabled will cause `play` to
+    // continually raise errors and is unrecoverable until the device list changes.
+    if (QAudioDeviceInfo::availableDevices(QAudio::AudioOutput).empty()) {
         LOG(Warn, "LowAudioLatency: Try to init, but no audio output device is enabled.");
         return false;
     }
 
-    const auto device = QAudioDeviceInfo::defaultOutputDevice();
-    const auto format = CreateSilenceFormat(device);
-    if (!format.isValid()) {
-        LOG(Warn, "LowAudioLatency: Default output device has no valid PCM format.");
-        return false;
-    }
+    _mediaPlayer = std::make_unique<QMediaPlayer>();
+    _mediaPlaylist = std::make_unique<QMediaPlaylist>();
 
-    _silenceDevice = std::make_unique<SilenceDevice>(format);
-    _audioOutput = std::make_unique<QAudioOutput>(device, format, this);
-    _deviceName = device.deviceName();
+    connect(
+        _mediaPlayer.get(), qOverload<QMediaPlayer::Error>(&QMediaPlayer::error), this,
+        &Controller::OnError);
 
-    LOG(Info, "LowAudioLatency: Format: {} Hz, {} channel(s), {} bit, sample type {}.",
-        format.sampleRate(), format.channelCount(), format.sampleSize(), format.sampleType());
-
-    connect(_audioOutput.get(), &QAudioOutput::stateChanged, this, &Controller::OnStateChanged);
+    _mediaPlaylist->addMedia(QUrl{"qrc:/Resource/Audio/Silence.mp3"});
+    _mediaPlaylist->setPlaybackMode(QMediaPlaylist::Loop);
+    _mediaPlayer->setPlaylist(_mediaPlaylist.get());
 
     _inited = true;
-
-    LOG(Info, "LowAudioLatency: Init successful. _enabled: {}", _enabled);
-
+    LOG(Info, "LowAudioLatency: Compatible media backend initialized.");
     return true;
 }
 
 bool Controller::StartWhenReady()
 {
     if (!_inited && !Initialize()) {
-        _deviceCheckTimer.stop();
         if (!_initTimer.isActive()) {
             _initTimer.start();
         }
         return false;
     }
+
     _initTimer.stop();
     Start();
-    _deviceCheckTimer.start();
     return true;
 }
 
 void Controller::ResetAudio()
 {
     Stop();
-    _audioOutput.reset();
-    _silenceDevice.reset();
-    _deviceName.clear();
+    _mediaPlayer.reset();
+    _mediaPlaylist.reset();
     _inited = false;
 }
 
@@ -289,7 +110,6 @@ void Controller::Control(bool enable)
     }
     else {
         _initTimer.stop();
-        _deviceCheckTimer.stop();
         ResetAudio();
     }
 }
@@ -308,75 +128,49 @@ void Controller::SetDeviceConnected(bool connected)
     if (!connected) {
         LOG(Info, "LowAudioLatency: Bound device disconnected; releasing the audio stream.");
         _initTimer.stop();
-        _deviceCheckTimer.stop();
         ResetAudio();
         return;
     }
 
-    LOG(Info, "LowAudioLatency: Bound device connected; starting the audio stream.");
+    LOG(Info, "LowAudioLatency: Bound device connected; starting the compatible media stream.");
     StartWhenReady();
 }
 
 void Controller::Start()
 {
-    if (!_inited || !_enabled || !_deviceConnected || !_audioOutput || !_silenceDevice) {
+    if (!_inited || !_enabled || !_deviceConnected || !_mediaPlayer) {
         return;
     }
 
-    if (_audioOutput->state() == QAudio::ActiveState || _audioOutput->state() == QAudio::IdleState)
-    {
-        return;
+    if (_mediaPlayer->state() != QMediaPlayer::PlayingState) {
+        _mediaPlayer->play();
     }
-
-    _silenceDevice->Start();
-    _audioOutput->start(_silenceDevice.get());
 }
 
 void Controller::Stop()
 {
-    if (_audioOutput) {
-        _audioOutput->stop();
-    }
-    if (_silenceDevice) {
-        _silenceDevice->Stop();
+    if (_mediaPlayer) {
+        _mediaPlayer->stop();
     }
 }
 
-void Controller::CheckOutputDevice()
-{
-    if (!_enabled || !_deviceConnected) {
-        return;
-    }
-
-    const auto device = QAudioDeviceInfo::defaultOutputDevice();
-    if (!device.isNull() && device.deviceName() == _deviceName) {
-        return;
-    }
-
-    LOG(Info, "LowAudioLatency: Default output device changed; recreating the silence stream.");
-    ResetAudio();
-    StartWhenReady();
-}
-
-void Controller::OnStateChanged(QAudio::State state)
+void Controller::OnError(QMediaPlayer::Error error)
 {
     if (!_enabled) {
         return;
     }
 
-    if (state == QAudio::StoppedState && _audioOutput && _audioOutput->error() != QAudio::NoError) {
-        LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", _audioOutput->error());
-        // Do not destroy QAudioOutput while it is emitting stateChanged.
-        const auto *failedOutput = _audioOutput.get();
-        QTimer::singleShot(0, this, [this, failedOutput] {
-            if (!_enabled || !_deviceConnected || _audioOutput.get() != failedOutput) {
-                return;
-            }
-            _deviceCheckTimer.stop();
-            ResetAudio();
-            _initTimer.start();
-        });
-    }
+    LOG(Warn, "LowAudioLatency::Controller error: {}. Reinit later.", error);
+
+    // Do not destroy QMediaPlayer while it is emitting its error signal.
+    const auto *failedPlayer = _mediaPlayer.get();
+    QTimer::singleShot(0, this, [this, failedPlayer] {
+        if (!_enabled || !_deviceConnected || _mediaPlayer.get() != failedPlayer) {
+            return;
+        }
+        ResetAudio();
+        _initTimer.start();
+    });
 }
 
 } // namespace Core::LowAudioLatency

--- a/Source/Core/LowAudioLatency.h
+++ b/Source/Core/LowAudioLatency.h
@@ -19,30 +19,15 @@
 #pragma once
 
 #include <chrono>
-#include <cstdint>
 #include <memory>
-#include <vector>
 
-#include <QAudioFormat>
-#include <QAudioOutput>
-#include <QList>
-#include <QString>
+#include <QMediaPlayer>
+#include <QMediaPlaylist>
 #include <QTimer>
 
 using namespace std::chrono_literals;
 
 namespace Core::LowAudioLatency {
-
-namespace Details {
-
-std::vector<QAudioFormat> BuildSilenceFormatCandidates(
-    const QList<int> &sampleSizes, const QList<QAudioFormat::SampleType> &sampleTypes,
-    const QList<QAudioFormat::Endian> &byteOrders);
-std::vector<uint8_t> CreateSilentFrame(const QAudioFormat &format);
-
-} // namespace Details
-
-class SilenceDevice;
 
 class Controller : public QObject
 {
@@ -58,12 +43,9 @@ Q_SIGNALS:
 
 private:
     constexpr static inline auto kRetryInterval = 30s;
-    constexpr static inline auto kDeviceCheckInterval = 5s;
-    std::unique_ptr<QAudioOutput> _audioOutput;
-    std::unique_ptr<SilenceDevice> _silenceDevice;
+    std::unique_ptr<QMediaPlayer> _mediaPlayer;
+    std::unique_ptr<QMediaPlaylist> _mediaPlaylist;
     QTimer _initTimer;
-    QTimer _deviceCheckTimer;
-    QString _deviceName;
     bool _inited{false}, _enabled{false}, _deviceConnected{false};
 
     bool Initialize();
@@ -74,8 +56,7 @@ private:
 
     void Start();
     void Stop();
-    void CheckOutputDevice();
-    void OnStateChanged(QAudio::State state);
+    void OnError(QMediaPlayer::Error error);
 };
 
 } // namespace Core::LowAudioLatency

--- a/Source/Resource/Resource.qrc
+++ b/Source/Resource/Resource.qrc
@@ -11,5 +11,6 @@
         <file>Video/AirPods_Pro_3.avi</file>
         <file>Video/AirPods_Max.avi</file>
         <file>Video/Beats_Fit_Pro.avi</file>
+        <file>Audio/Silence.mp3</file>
     </qresource>
 </RCC>

--- a/Tests/AirPodsDomainTests.cpp
+++ b/Tests/AirPodsDomainTests.cpp
@@ -8,7 +8,6 @@
 
 #include <Config.h>
 #include "Source/Core/AirPods.h"
-#include "Source/Core/LowAudioLatency.h"
 #include "Source/Core/Settings.h"
 #include "Source/Core/SettingsRepository.h"
 #include "Source/Core/Update.h"
@@ -114,8 +113,7 @@ private Q_SLOTS:
     void MergesAdvertisementsFromBothSides();
     void RejectsAdvertisementsFromDifferentModels();
     void AcceptsKnownModelAfterUnknownAdvertisement();
-    void BuildsLowBandwidthSilenceFormats();
-    void CreatesCorrectPcmSilenceFrames();
+    void PackagesCompatibleLowLatencySilence();
     void LoadsSettingsThroughRepository();
     void PropagatesQuickConnectSettings();
     void RejectsNullSettingsRepository();
@@ -166,61 +164,14 @@ void AirPodsDomainTests::ResolvesAirPodsMaxUsbCDisplayName()
         QString{"AirPods Max"});
 }
 
-void AirPodsDomainTests::BuildsLowBandwidthSilenceFormats()
+void AirPodsDomainTests::PackagesCompatibleLowLatencySilence()
 {
-    const auto candidates = Core::LowAudioLatency::Details::BuildSilenceFormatCandidates(
-        {16, 8, 16}, {QAudioFormat::Float, QAudioFormat::UnSignedInt, QAudioFormat::SignedInt},
-        {QAudioFormat::BigEndian, QAudioFormat::LittleEndian});
+    QFile qrc{QString{APD_SOURCE_DIR} + "/Source/Resource/Resource.qrc"};
+    QVERIFY(qrc.open(QIODevice::ReadOnly | QIODevice::Text));
 
-    QCOMPARE(candidates.size(), size_t{12});
-    for (const auto &candidate : candidates) {
-        QCOMPARE(candidate.sampleRate(), 8000);
-        QCOMPARE(candidate.channelCount(), 1);
-        QCOMPARE(candidate.codec(), QString{"audio/pcm"});
-    }
-
-    QCOMPARE(candidates.front().sampleSize(), 8);
-    QCOMPARE(candidates.front().sampleType(), QAudioFormat::SignedInt);
-    QCOMPARE(candidates.front().byteOrder(), QAudioFormat::LittleEndian);
-}
-
-void AirPodsDomainTests::CreatesCorrectPcmSilenceFrames()
-{
-    const auto makeFormat = [](int sampleSize, int channelCount,
-                               QAudioFormat::SampleType sampleType,
-                               QAudioFormat::Endian byteOrder) {
-        QAudioFormat format;
-        format.setSampleSize(sampleSize);
-        format.setChannelCount(channelCount);
-        format.setSampleType(sampleType);
-        format.setByteOrder(byteOrder);
-        return format;
-    };
-
-    const std::vector<uint8_t> signedSilence{0, 0, 0, 0};
-    QVERIFY(
-        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
-            16, 2, QAudioFormat::SignedInt, QAudioFormat::LittleEndian)) == signedSilence);
-
-    const std::vector<uint8_t> floatSilence{0, 0, 0, 0};
-    QVERIFY(
-        Core::LowAudioLatency::Details::CreateSilentFrame(
-            makeFormat(32, 1, QAudioFormat::Float, QAudioFormat::LittleEndian)) == floatSilence);
-
-    const std::vector<uint8_t> unsignedLittleEndian{0, 0x80, 0, 0x80};
-    QVERIFY(
-        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
-            16, 2, QAudioFormat::UnSignedInt, QAudioFormat::LittleEndian)) == unsignedLittleEndian);
-
-    const std::vector<uint8_t> unsignedBigEndian{0x80, 0};
-    QVERIFY(
-        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
-            16, 1, QAudioFormat::UnSignedInt, QAudioFormat::BigEndian)) == unsignedBigEndian);
-
-    const std::vector<uint8_t> unsignedTwentyBit{0, 0, 0x08};
-    QVERIFY(
-        Core::LowAudioLatency::Details::CreateSilentFrame(makeFormat(
-            20, 1, QAudioFormat::UnSignedInt, QAudioFormat::LittleEndian)) == unsignedTwentyBit);
+    const auto qrcContents = QString::fromUtf8(qrc.readAll());
+    QVERIFY(qrcContents.contains("<file>Audio/Silence.mp3</file>"));
+    QVERIFY(QFile::exists(QString{APD_SOURCE_DIR} + "/Source/Resource/Audio/Silence.mp3"));
 }
 
 void AirPodsDomainTests::ParsesAdvertisementState()


### PR DESCRIPTION
## Summary

- replace the raw PCM keep-alive stream introduced in v0.5.1 with the QMediaPlayer silence backend used in v0.4.2
- retain connection-aware lazy initialization, teardown, retry, and deferred error recovery
- package Silence.mp3 again and add regression coverage for the resource

## Rationale

Reports in #216 indicate that v0.5.1 produces audible humming or hiss while v0.4.2 does not. The relevant behavioral change was the low-latency backend moving from media playback to a continuously active raw PCM output. Restoring the compatible backend removes that regression while preserving the newer connection lifecycle behavior.

## Verification

- full Win32 RelWithDebInfo application build
- AirPodsDomainTests
- QuickConnectTests
- ctest: 2/2 test suites passed
- git diff --check

Audible hiss cannot be reproduced automatically without an affected AirPods and Windows audio-driver combination, so a reporter hardware A/B test is still recommended.

Fixes #216