### PR TITLE
docs: remove contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,3 @@ See the [Build Instructions](/Docs/Build.md).
 * [OpenPods](https://github.com/adolfintel/OpenPods)
 * [Discontinued Privacy: Personal Data Leaks in Apple Bluetooth-Low-Energy Continuity Protocols](https://hal.inria.fr/hal-02394619/document)
 * [MagicPods](https://magicpods.app/)
-
-### Contributors
-* [@aizuon](https://github.com/aizuon) — idle CPU and low-latency audio rework, contributed in [#199](https://github.com/SpriteOvO/AirPodsDesktop/pull/199) and merged through [#210](https://github.com/SpriteOvO/AirPodsDesktop/pull/210); see the [performance notes](/Docs/Performance.md)


### PR DESCRIPTION
## Summary

Remove the dedicated Contributors section from README.md. Contributor attribution does not need to be maintained as a separate README block.

## Verification

- confirmed the diff only removes the Contributors heading and its entry
- git diff --check

No runtime tests were required for this documentation-only change.