### PR TITLE
chore: prepare v0.5.2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(
 
 project(
     AirPodsDesktop
-    VERSION 0.5.1 # Don't forget to bump the version in `vcpkg.json` as well
+    VERSION 0.5.2 # Don't forget to bump the version in `vcpkg.json` as well
     LANGUAGES C CXX
     DESCRIPTION "AirPods desktop user experience enhancement program"
     HOMEPAGE_URL "https://github.com/${APD_GITHUB_OWNER}/${APD_GITHUB_REPOSITORY}"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "airpods-desktop",
-  "version-string": "0.5.1",
+  "version-string": "0.5.2",
   "dependencies": [
     {
       "name": "cpr",


### PR DESCRIPTION
## Summary

- bump the CMake project version from 0.5.1 to 0.5.2
- synchronize the vcpkg manifest version at 0.5.2

## Included fixes

- #218 improves taskbar status geometry on mixed-DPI and non-primary monitor layouts
- #219 restores the compatible low-latency playback backend to address the hiss regression reported in #216
- #220 removes the README Contributors block

## Verification

- Win32 RelWithDebInfo build succeeded
- NSIS installer generated as AirPodsDesktop-0.5.2-win32.exe
- AirPodsDomainTests passed
- QuickConnectTests passed
- CTest: 2/2 test suites passed
- git diff --check passed